### PR TITLE
Add BIO timeout

### DIFF
--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -2075,6 +2075,91 @@ sealed abstract class BIO[+E, +A] extends Serializable {
       end <- BIO.clock.monotonic(NANOSECONDS)
     } yield (FiniteDuration(end - start, NANOSECONDS), a)
 
+  /** Returns a Task that mirrors the source Task but returns `None`
+    * in case the given duration passes without the
+    * task emitting any item. Otherwise, returns `Some` of the resulting value.
+    */
+  final def timeout(after: FiniteDuration): BIO[E, Option[A]] =
+    timeoutL(now(after))
+
+  /** Returns a Task that mirrors the source Task but that triggers a
+    * specified error in case the given duration passes
+    * without the task emitting any item.
+    * @param error `Error` raised after given duration passes
+    */
+  final def timeoutWith[E1 >: E, B >: A](after: FiniteDuration, error: E1): BIO[E1, B] =
+    timeoutTo(after, raiseError(error))
+
+  /** Returns a Task that mirrors the source Task but switches to the
+    * given backup Task in case the given duration passes without the
+    * source emitting any item.
+    */
+  final def timeoutTo[E1 >: E, B >: A](after: FiniteDuration, backup: BIO[E1, B]): BIO[E1, B] =
+    timeoutToL(now(after), backup)
+
+  /** Returns a Task that mirrors the source Task but returns `None`
+    * in case the given duration passes without the
+    * task emitting any item. Otherwise, returns `Some` of the resulting value.
+    */
+  final def timeoutL(after: UIO[FiniteDuration]): BIO[E, Option[A]] =
+    this.map(Some(_)).timeoutToL(after, now(None))
+
+  /** Returns a Task that mirrors the source Task but switches to the
+    * given backup Task in case the given duration passes without the
+    * source emitting any item.
+    *
+    * Useful when timeout is variable, e.g. when task is running in a loop
+    * with deadline semantics.
+    *
+    * Example:
+    * {{{
+    *   import monix.execution.Scheduler.Implicits.global
+    *   import scala.concurrent.duration._
+    *
+    *   val deadline = 10.seconds.fromNow
+    *
+    *   val singleCallTimeout = 2.seconds
+    *
+    *   // re-evaluate deadline time on every request
+    *   val actualTimeout = UIO(singleCallTimeout.min(deadline.timeLeft))
+    *   val error = BIO.raiseError(new TimeoutException("Task timed-out"))
+    *
+    *   // expensive remote call
+    *   def call(): Unit = ()
+    *
+    *   val remoteCall = BIO(call())
+    *     .timeoutToL(actualTimeout, error)
+    *     .onErrorRestart(100)
+    *     .timeout(deadline.time)
+    * }}}
+    * Note that this method respects the timeout task evaluation duration,
+    * e.g. if it took 3 seconds to evaluate `after`
+    * to a value of `5 seconds`, then this task will timeout
+    * in exactly 5 seconds from the moment computation started,
+    * which means in 2 seconds after the timeout task has been evaluated.
+    *
+    **/
+  final def timeoutToL[E1 >: E, B >: A](after: UIO[FiniteDuration], backup: BIO[E1, B]): BIO[E1, B] = {
+    val timeoutTask: UIO[Unit] =
+      after.timed.flatMap {
+        case (took, need) =>
+          val left = need - took
+          if (left.length <= 0) {
+            UIO.unit
+          } else {
+            sleep(left)
+          }
+      }
+
+    race(this, timeoutTask).flatMap {
+      case Left(a) =>
+        now(a)
+
+      case Right(_) =>
+        backup
+    }
+  }
+
   /** Hides all errors from the return type and raises them in the internal channel.
     *
     * Use if you have a method that returns a possible error but you can't recover


### PR DESCRIPTION
Addresses #16.
Getting early feedback. I'll fix tests & docs afterwards.

In Monix Task, `timeout` & `timeoutL` will throw `TimeoutException`. This is different compared to BIO, since the error type might be different. I'm returning an Option instead, since throwing `TimeoutException` is not an option I believe.

If they want to return their own error, there is `timeoutWith`.

WDYT @Avasil?