### PR TITLE
Add BIO.evalTotal and BIO.suspendTotal

### DIFF
--- a/core/jvm/src/test/scala/monix/bio/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
+++ b/core/jvm/src/test/scala/monix/bio/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
@@ -19,13 +19,11 @@ package monix.bio
 
 import cats.effect.IO
 import cats.effect.laws.discipline._
-import cats.laws.discipline.{CoflatMapTests, BifunctorTests, ParallelTests, ApplicativeTests}
-import cats.{Eq, Applicative}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests}
+import cats.{Applicative, Eq}
 import monix.bio.instances.CatsParallelForTask
-import monix.execution.schedulers.TestScheduler
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import scala.concurrent.ExecutionContext.global
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
 

--- a/core/jvm/src/test/scala/monix/bio/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
+++ b/core/jvm/src/test/scala/monix/bio/TypeClassLawsForTaskRunSyncUnsafeSuite.scala
@@ -19,9 +19,9 @@ package monix.bio
 
 import cats.effect.IO
 import cats.effect.laws.discipline._
-import cats.laws.discipline.{CoflatMapTests, BifunctorTests, ParallelTests, ApplicativeTests}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests}
 import cats.kernel.laws.discipline.MonoidTests
-import cats.{Eq, Applicative}
+import cats.{Applicative, Eq}
 import monix.bio.instances.CatsParallelForTask
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import scala.concurrent.ExecutionContext.global
@@ -109,7 +109,7 @@ class BaseTypeClassLawsForTaskRunSyncUnsafeSuite(implicit opts: BIO.Options)
 
   checkAll("Parallel[Task, Task.Par]", ParallelTests[Task, BIO.Par[Throwable, ?]].parallel[Int, Int])
 
- checkAll("Monoid[BIO[Throwable, Int]]", MonoidTests[BIO[Throwable, Int]].monoid)
+  checkAll("Monoid[BIO[Throwable, Int]]", MonoidTests[BIO[Throwable, Int]].monoid)
 
   checkAllAsync("Bifunctor[BIO[String, Int]]") { implicit ec =>
     BifunctorTests[BIO].bifunctor[String, String, String, Int, Int, Int]

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -2313,19 +2313,34 @@ object BIO extends TaskInstancesLevel0 {
   def pure[A](a: A): UIO[A] = now(a)
 
   /** Returns a task that on execution is always finishing in error
-    * emitting the specified exception.
+    * emitting the specified value in a typed error channel.
     */
   def raiseError[E](ex: E): BIO[E, Nothing] =
     Error(ex)
 
+  /** Returns a task that on execution is always finishing in a fatal (unexpected) error
+    * emitting the specified exception.
+    */
   def raiseFatalError(ex: Throwable): UIO[Nothing] =
     FatalError(ex)
 
-  /** Promote a non-strict value representing a Task to a Task of the
-    * same type.
+  /** Defers the creation of a `Task` in case it is effectful.
+    *
+    * It will catch any exceptions thrown in `fa` and expose them as
+    * a typed error.
+    *
+    * @see [[deferTotal]] if `fa` is not expected to throw any exceptions.
     */
-  def defer[E, A](fa: => BIO[E, A]): BIO[E, A] =
+  def defer[A](fa: => Task[A]): Task[A] =
     Suspend(fa _)
+
+  /** Defers the creation of a `BIO` in case it is effectful.
+    *
+    * @see [[defer]] if `fa` is expected to throw exceptions and you would
+    *      like to expose them as typed errors.
+    */
+  def deferTotal[E, A](fa: => BIO[E, A]): BIO[E, A] =
+    SuspendTotal(fa _)
 
   /** Defers the creation of a `Task` by using the provided
     * function, which has the ability to inject a needed
@@ -2412,8 +2427,12 @@ object BIO extends TaskInstancesLevel0 {
     TaskFromFuture.deferAction(f)
 
   /** Alias for [[defer]]. */
-  def suspend[E, A](fa: => BIO[E, A]): BIO[E, A] =
+  def suspend[A](fa: => Task[A]): Task[A] =
     Suspend(fa _)
+
+  /** Alias for [[deferTotal]]. */
+  def suspendTotal[E, A](fa: => BIO[E, A]): BIO[E, A] =
+    SuspendTotal(fa _)
 
   /** Promote a non-strict value, a thunk, to a `Task`, catching exceptions
     * in the process.
@@ -2422,9 +2441,24 @@ object BIO extends TaskInstancesLevel0 {
     * value each time the `Task` is executed, behaving like a function.
     *
     * @param a is the thunk to process on evaluation
+    *
+    * @see [[evalTotal]] if `a` is not expected to throw any exceptions.
     */
   def eval[A](a: => A): Task[A] =
     Eval(a _)
+
+  /** Promote a non-strict value which does not throw any unexpected errors to `UIO`.
+    *
+    * Note that since `BIO` is not memoized or strict, this will recompute the
+    * value each time the `BIO` is executed, behaving like a function.
+    *
+    * @param a is the thunk to process on evaluation
+    *
+    * @see [[eval]] if `a` is expected to throw exceptions and you want to expose them
+    *      in a typed error channel.
+    */
+  def evalTotal[A](a: => A): UIO[A] =
+    EvalTotal(a _)
 
   /** Lifts a non-strict value, a thunk, to a `Task` that will trigger a logical
     * fork before evaluation.
@@ -2479,7 +2513,7 @@ object BIO extends TaskInstancesLevel0 {
     * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
     */
   def tailRecM[E, A, B](a: A)(f: A => BIO[E, Either[A, B]]): BIO[E, B] =
-    BIO.defer(f(a)).flatMap {
+    BIO.deferTotal(f(a)).flatMap {
       case Left(continueA) => tailRecM(continueA)(f)
       case Right(b) => BIO.now(b)
     }
@@ -3601,10 +3635,16 @@ object BIO extends TaskInstancesLevel0 {
   }
 
   /** [[BIO]] state describing an non-strict synchronous value. */
-  private[bio] final case class Eval[+E, +A](thunk: () => A) extends BIO[E, A]
+  private[bio] final case class Eval[+A](thunk: () => A) extends BIO[Throwable, A]
+
+  /** [[BIO]] state describing an non-strict synchronous value which doesn't throw any expected errors. */
+  private[bio] final case class EvalTotal[+A](thunk: () => A) extends BIO[Nothing, A]
 
   /** Internal state, the result of [[BIO.defer]] */
-  private[bio] final case class Suspend[+E, +A](thunk: () => BIO[E, A]) extends BIO[E, A]
+  private[bio] final case class Suspend[+A](thunk: () => BIO[Throwable, A]) extends BIO[Throwable, A]
+
+  /** Internal state, the result of [[BIO.deferTotal]]*/
+  private[bio] final case class SuspendTotal[+E, +A](thunk: () => BIO[E, A]) extends BIO[E, A]
 
   /** Internal [[BIO]] state that is the result of applying `flatMap`. */
   private[bio] final case class FlatMap[E, E1, A, +B](source: BIO[E, A], f: A => BIO[E1, B]) extends BIO[E1, B]

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -3890,14 +3890,14 @@ private[bio] abstract class TaskInstancesLevel1 extends TaskInstancesLevel2 {
     new CatsConcurrentEffectForTask
   }
 
-    /** Given an `A` type that has a `cats.Semigroup[A]` implementation,
+  /** Given an `A` type that has a `cats.Semigroup[A]` implementation,
     * then this provides the evidence that `BIO[E, A]` also has
     * a `Semigroup[ BIO[E, A] ]` implementation.
     *
     * This has a lower-level priority than [[BIO.catsMonoid]]
     * in order to avoid conflicts.
     */
-    implicit def catsSemigroup[E, A](implicit A: Semigroup[A]): Semigroup[BIO[E, A]] =
+  implicit def catsSemigroup[E, A](implicit A: Semigroup[A]): Semigroup[BIO[E, A]] =
     new CatsMonadToSemigroup[BIO[E, ?], A]()(new CatsBaseForTask[E], A)
 }
 

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -25,7 +25,7 @@ object UIO {
     * @see See [[monix.bio.BIO.apply]]
     */
   def apply[A](a: => A): UIO[A] =
-    BIO.Eval(a _)
+    BIO.EvalTotal(a _)
 
   /**
     * @see See [[monix.bio.BIO.now]]
@@ -49,25 +49,43 @@ object UIO {
     * @see See [[monix.bio.BIO.defer]]
     */
   def defer[A](fa: => UIO[A]): UIO[A] =
-    BIO.defer(fa)
+    BIO.deferTotal(fa)
+
+  /**
+    * @see See [[monix.bio.BIO.deferTotal]]
+    */
+  def deferTotal[A](fa: => UIO[A]): UIO[A] =
+    BIO.deferTotal(fa)
 
   /**
     * @see See [[monix.bio.BIO.suspend]]
     */
   def suspend[A](fa: => UIO[A]): UIO[A] =
-    BIO.suspend(fa)
+    BIO.suspendTotal(fa)
+
+  /**
+    * @see See [[monix.bio.BIO.suspendTotal]]
+    */
+  def suspendTotal[A](fa: => UIO[A]): UIO[A] =
+    BIO.suspendTotal(fa)
 
   /**
     * @see See [[monix.bio.BIO.eval]]
     */
   def eval[A](a: => A): UIO[A] =
-    BIO.Eval(a _)
+    BIO.EvalTotal(a _)
+
+  /**
+    * @see See [[monix.bio.BIO.evalTotal]]
+    */
+  def evalTotal[A](a: => A): UIO[A] =
+    BIO.EvalTotal(a _)
 
   /**
     * @see See [[monix.bio.BIO.evalAsync]]
     */
   def evalAsync[A](a: => A): UIO[A] =
-    BIO.Eval(a _).executeAsync
+    BIO.EvalTotal(a _).executeAsync
 
   /**
     * @see See [[monix.bio.BIO.never]]

--- a/core/shared/src/main/scala/monix/bio/instances/CatsMonadToMonoid.scala
+++ b/core/shared/src/main/scala/monix/bio/instances/CatsMonadToMonoid.scala
@@ -31,7 +31,7 @@ import cats.{Monad, Monoid, Semigroup}
   * for every monad.
   */
 class CatsMonadToMonoid[F[_], A](implicit F: Monad[F], A: Monoid[A])
-  extends CatsMonadToSemigroup[F, A] with Monoid[F[A]] {
+    extends CatsMonadToSemigroup[F, A] with Monoid[F[A]] {
 
   override def empty: F[A] =
     F.pure(A.empty)

--- a/core/shared/src/main/scala/monix/bio/internal/TaskBracket.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskBracket.scala
@@ -223,7 +223,7 @@ private[monix] object TaskBracket {
       // the connection is actually made uncancelable
       val task =
         if (ctx.options.autoCancelableRunLoops)
-          BIO.suspend(unsafeApply(b))
+          BIO.suspendTotal(unsafeApply(b))
         else
           unsafeApply(b)
 
@@ -236,7 +236,7 @@ private[monix] object TaskBracket {
       // the connection is actually made uncancelable
       val task =
         if (ctx.options.autoCancelableRunLoops)
-          BIO.suspend(unsafeRecover(e))
+          BIO.suspendTotal(unsafeRecover(e))
         else
           unsafeRecover(e)
 
@@ -249,7 +249,7 @@ private[monix] object TaskBracket {
       // the connection is actually made uncancelable
       val task =
         if (ctx.options.autoCancelableRunLoops)
-          BIO.suspend(unsafeRecoverFatal(e))
+          BIO.suspendTotal(unsafeRecoverFatal(e))
         else
           unsafeRecoverFatal(e)
 

--- a/core/shared/src/main/scala/monix/bio/internal/TaskCancellation.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskCancellation.scala
@@ -106,7 +106,7 @@ private[bio] object TaskCancellation {
     cb: Callback[E, A],
     e: E): CancelToken[BIO[E, ?]] = {
 
-    BIO.suspend {
+    BIO.suspendTotal {
       if (waitsForResult.getAndSet(false))
         conn2.cancel.map { _ =>
           conn.tryReactivate()

--- a/core/shared/src/main/scala/monix/bio/internal/TaskConnection.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskConnection.scala
@@ -152,7 +152,7 @@ private[bio] object TaskConnection {
         PaddingStrategy.LeftRight128
       )
 
-    val cancel: BIO[E, Unit] = BIO.suspend {
+    val cancel: BIO[E, Unit] = BIO.suspendTotal {
       state.getAndSet(null) match {
         case null | Nil =>
           BIO.unit

--- a/core/shared/src/main/scala/monix/bio/internal/TaskConnectionComposite.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskConnectionComposite.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
 private[bio] final class TaskConnectionComposite[E] private (stateRef: AtomicAny[State]) {
 
   val cancel: CancelToken[BIO[E, ?]] =
-    BIO.suspend {
+    BIO.suspendTotal {
       stateRef.getAndSet(Cancelled) match {
         case Cancelled => BIO.unit
         case Active(set) =>

--- a/core/shared/src/main/scala/monix/bio/internal/TaskConnectionRef.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskConnectionRef.scala
@@ -83,7 +83,7 @@ private[bio] final class TaskConnectionRef[E] extends CancelableF[BIO[E, ?]] {
             // $COVERAGE-ON$
           }
       }
-    BIO.suspend(loop())
+    BIO.suspendTotal(loop())
   }
 
   private def raiseError(): Nothing = {

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRestartCallback.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRestartCallback.scala
@@ -95,7 +95,7 @@ private[internal] abstract class TaskRestartCallback(contextInit: Context[Any], 
       }
     } else {
       // $COVERAGE-OFF$
-      context.scheduler.reportFailure(WrappedException(error))
+      context.scheduler.reportFailure(WrappedException.wrap(error))
       // $COVERAGE-ON$
     }
 

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRunLoop.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRunLoop.scala
@@ -19,7 +19,20 @@ package monix.bio.internal
 
 import cats.effect.CancelToken
 import monix.bio.BIO
-import monix.bio.BIO.{Async, Context, ContextSwitch, Error, Eval, FatalError, FlatMap, Map, Now, Suspend}
+import monix.bio.BIO.{
+  Async,
+  Context,
+  ContextSwitch,
+  Error,
+  Eval,
+  EvalTotal,
+  FatalError,
+  FlatMap,
+  Map,
+  Now,
+  Suspend,
+  SuspendTotal
+}
 import monix.execution.internal.collection.ChunkedArrayStack
 import monix.execution.misc.Local
 import monix.execution.{CancelableFuture, ExecutionModel, Scheduler}
@@ -97,6 +110,17 @@ private[bio] object TaskRunLoop {
                 current = Error(e)
             }
 
+          case EvalTotal(thunk) =>
+            try {
+              unboxed = thunk().asInstanceOf[AnyRef]
+              hasUnboxed = true
+              current = null
+            } catch {
+              case e if NonFatal(e) =>
+                // Eval and Suspend are allowed to catch errors
+                current = FatalError(e)
+            }
+
           case bindNext @ Map(fa, _, _) =>
             if (bFirstRef ne null) {
               if (bRestRef eq null) bRestRef = ChunkedArrayStack()
@@ -112,6 +136,15 @@ private[bio] object TaskRunLoop {
             } catch {
               // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = Error(ex)
+            }
+
+          case SuspendTotal(thunk) =>
+            // Try/catch described as statement to prevent ObjectRef ;-)
+            try {
+              current = thunk()
+            } catch {
+              // Eval and Suspend are allowed to catch errors
+              case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
           case Error(error) =>
@@ -304,6 +337,17 @@ private[bio] object TaskRunLoop {
                 current = Error(e)
             }
 
+          case EvalTotal(thunk) =>
+            try {
+              unboxed = thunk().asInstanceOf[AnyRef]
+              hasUnboxed = true
+              current = null
+            } catch {
+              case e if NonFatal(e) =>
+                // Eval and Suspend are allowed to catch errors
+                current = FatalError(e)
+            }
+
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
               if (bRest eq null) bRest = ChunkedArrayStack()
@@ -320,6 +364,15 @@ private[bio] object TaskRunLoop {
               case ex if NonFatal(ex) =>
                 // Eval and Suspend are allowed to catch errors
                 current = Error(ex)
+            }
+
+          case SuspendTotal(thunk) =>
+            // Try/catch described as statement to prevent ObjectRef ;-)
+            try {
+              current = thunk()
+            } catch {
+              // Eval and Suspend are allowed to catch errors
+              case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
           case Error(error) =>
@@ -441,6 +494,17 @@ private[bio] object TaskRunLoop {
                 current = Error(e)
             }
 
+          case EvalTotal(thunk) =>
+            try {
+              unboxed = thunk().asInstanceOf[AnyRef]
+              hasUnboxed = true
+              current = null
+            } catch {
+              case e if NonFatal(e) =>
+                // Eval and Suspend are allowed to catch errors
+                current = FatalError(e)
+            }
+
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
               if (bRest eq null) bRest = ChunkedArrayStack()
@@ -456,6 +520,15 @@ private[bio] object TaskRunLoop {
             } catch {
               // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = Error(ex)
+            }
+
+          case SuspendTotal(thunk) =>
+            // Try/catch described as statement to prevent ObjectRef ;-)
+            try {
+              current = thunk()
+            } catch {
+              // Eval and Suspend are allowed to catch errors
+              case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
           case Error(error) =>
@@ -557,6 +630,17 @@ private[bio] object TaskRunLoop {
                 current = Error(e)
             }
 
+          case EvalTotal(thunk) =>
+            try {
+              unboxed = thunk().asInstanceOf[AnyRef]
+              hasUnboxed = true
+              current = null
+            } catch {
+              case e if NonFatal(e) =>
+                // Eval and Suspend are allowed to catch errors
+                current = FatalError(e)
+            }
+
           case bindNext @ Map(fa, _, _) =>
             if (bFirst ne null) {
               if (bRest eq null) bRest = ChunkedArrayStack()
@@ -572,6 +656,15 @@ private[bio] object TaskRunLoop {
             } catch {
               // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = Error(ex)
+            }
+
+          case SuspendTotal(thunk) =>
+            // Try/catch described as statement to prevent ObjectRef ;-)
+            try {
+              current = thunk()
+            } catch {
+              // Eval and Suspend are allowed to catch errors
+              case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
           case Error(error) =>

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRunLoop.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRunLoop.scala
@@ -117,7 +117,6 @@ private[bio] object TaskRunLoop {
               current = null
             } catch {
               case e if NonFatal(e) =>
-                // Eval and Suspend are allowed to catch errors
                 current = FatalError(e)
             }
 
@@ -143,7 +142,6 @@ private[bio] object TaskRunLoop {
             try {
               current = thunk()
             } catch {
-              // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
@@ -344,7 +342,6 @@ private[bio] object TaskRunLoop {
               current = null
             } catch {
               case e if NonFatal(e) =>
-                // Eval and Suspend are allowed to catch errors
                 current = FatalError(e)
             }
 
@@ -371,7 +368,6 @@ private[bio] object TaskRunLoop {
             try {
               current = thunk()
             } catch {
-              // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
@@ -501,7 +497,6 @@ private[bio] object TaskRunLoop {
               current = null
             } catch {
               case e if NonFatal(e) =>
-                // Eval and Suspend are allowed to catch errors
                 current = FatalError(e)
             }
 
@@ -527,7 +522,6 @@ private[bio] object TaskRunLoop {
             try {
               current = thunk()
             } catch {
-              // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = FatalError(ex)
             }
 
@@ -637,7 +631,6 @@ private[bio] object TaskRunLoop {
               current = null
             } catch {
               case e if NonFatal(e) =>
-                // Eval and Suspend are allowed to catch errors
                 current = FatalError(e)
             }
 
@@ -663,7 +656,6 @@ private[bio] object TaskRunLoop {
             try {
               current = thunk()
             } catch {
-              // Eval and Suspend are allowed to catch errors
               case ex if NonFatal(ex) => current = FatalError(ex)
             }
 

--- a/core/shared/src/main/scala/monix/bio/internal/TaskSequence.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskSequence.scala
@@ -39,7 +39,7 @@ private[bio] object TaskSequence {
       }
     }
 
-    BIO.defer {
+    BIO.suspendTotal {
       val cursor: Iterator[BIO[E, A]] = toIterator(in)
       loop(cursor, newBuilder(bf, in))
     }
@@ -60,7 +60,7 @@ private[bio] object TaskSequence {
       }
     }
 
-    BIO.defer {
+    BIO.suspendTotal {
       loop(toIterator(in), newBuilder(bf, in))
     }
   }

--- a/core/shared/src/main/scala/monix/bio/internal/UnsafeCancelUtils.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/UnsafeCancelUtils.scala
@@ -46,7 +46,7 @@ private[bio] object UnsafeCancelUtils {
     if (cursor.isEmpty)
       BIO.unit
     else
-      BIO.suspend {
+      BIO.suspendTotal {
         val frame = new CancelAllFrame(cursor.iterator)
         frame.loop()
       }

--- a/core/shared/src/test/scala/monix/bio/TaskDeferActionSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskDeferActionSuite.scala
@@ -23,14 +23,14 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskDeferActionSuite extends BaseTestSuite {
-  test("Task.deferAction works") { implicit s =>
-    def measureLatency[A](source: Task[A]): Task[(A, Long)] =
-      Task.deferAction { implicit s =>
+  test("BIO.deferAction works") { implicit s =>
+    def measureLatency[E, A](source: BIO[E, A]): BIO[E, (A, Long)] =
+      BIO.deferAction { implicit s =>
         val start = s.clockMonotonic(MILLISECONDS)
         source.map(a => (a, s.clockMonotonic(MILLISECONDS) - start))
       }
 
-    val task = measureLatency(Task.now("hello").delayExecution(1.second))
+    val task = measureLatency(BIO.now("hello").delayExecution(1.second))
     val f = task.runToFuture
 
     s.tick()
@@ -40,27 +40,36 @@ object TaskDeferActionSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(("hello", 1000)))))
   }
 
-  test("Task.deferAction works for failed tasks") { implicit s =>
-    val dummy = DummyException("dummy")
-    val task = Task.deferAction(_ => Task.raiseError(dummy))
+  test("BIO.deferAction works for failed tasks") { implicit s =>
+    val dummy = "dummy"
+    val task = BIO.deferAction(_ => BIO.raiseError(dummy))
     val f = task.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("Task.deferAction protects against user error") { implicit s =>
+  test("BIO.deferAction protects against user error") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task.deferAction(_ => throw dummy)
+    val task = BIO.deferAction(_ => throw dummy)
     val f = task.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
-  test("Task.deferAction is stack safe") { implicit sc =>
+  test("BIO.deferAction should properly cast errors") { implicit s =>
+    val dummy = DummyException("dummy")
+    val task = BIO.deferAction[Int, Int](_ => throw dummy)
+    val f = task.onErrorHandle(identity).runToFuture
+
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("BIO.deferAction is stack safe") { implicit sc =>
     def loop(n: Int, acc: Int): Task[Int] =
-      Task.deferAction { _ =>
+      BIO.deferAction { _ =>
         if (n > 0)
           loop(n - 1, acc + 1)
         else

--- a/core/shared/src/test/scala/monix/bio/TaskRaceSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskRaceSuite.scala
@@ -23,7 +23,7 @@ import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform
 
 import scala.concurrent.duration._
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 object TaskRaceSuite extends BaseTestSuite {
 //  test("Task.raceMany should switch to other") { implicit s =>

--- a/core/shared/src/test/scala/monix/bio/TaskSuspendSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskSuspendSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.bio
+
+import monix.execution.exceptions.DummyException
+
+import scala.util.{Failure, Success}
+
+object TaskSuspendSuite extends BaseTestSuite {
+  test("BIO.suspend should suspend evaluation") { implicit s =>
+    var wasTriggered = false
+    def trigger(): String = { wasTriggered = true; "result" }
+
+    val task = Task.suspend {
+      Task.now(trigger())
+    }
+    assert(!wasTriggered, "!wasTriggered")
+
+    val f = task.runToFuture
+    assert(wasTriggered, "wasTriggered")
+    assertEquals(f.value, Some(Success(Right("result"))))
+  }
+
+  test("BIO.suspend should protect against user code errors") { implicit s =>
+    val ex = DummyException("dummy")
+    val f = BIO.suspend[Int](throw ex).runToFuture
+
+    assertEquals(f.value, Some(Success(Left(ex))))
+    assertEquals(s.state.lastReportedError, null)
+  }
+
+  test("BIO.suspendTotal should protect against unexpected errors") { implicit s =>
+    val ex = DummyException("dummy")
+    val f = BIO.suspendTotal[Int, Int](throw ex).redeemFatal(_ => 10, identity).runToFuture
+    val g = BIO.suspendTotal[Int, Int](throw ex).onErrorHandle(_ => 10).runToFuture
+
+    assertEquals(f.value, Some(Success(Right(10))))
+    assertEquals(g.value, Some(Failure(ex)))
+    assertEquals(s.state.lastReportedError, null)
+  }
+}

--- a/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskSuite.scala
@@ -19,7 +19,7 @@ package monix.bio
 
 import cats.Applicative
 import cats.effect.laws.discipline.{ConcurrentEffectTests, ConcurrentTests}
-import cats.laws.discipline.{ApplicativeTests, CoflatMapTests, ParallelTests, SemigroupKTests, BifunctorTests}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests, SemigroupKTests}
 import monix.bio.instances.CatsParallelForTask
 
 object TypeClassLawsForTaskSuite

--- a/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskSuite.scala
@@ -20,7 +20,7 @@ package monix.bio
 import cats.Applicative
 import cats.effect.laws.discipline.{ConcurrentEffectTests, ConcurrentTests}
 import cats.kernel.laws.discipline.MonoidTests
-import cats.laws.discipline.{ApplicativeTests, CoflatMapTests, ParallelTests, SemigroupKTests, BifunctorTests}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests, SemigroupKTests}
 import monix.bio.instances.CatsParallelForTask
 
 object TypeClassLawsForTaskSuite
@@ -57,9 +57,9 @@ class BaseTypeClassLawsForTaskSuite(implicit opts: BIO.Options) extends BaseLaws
     ParallelTests[Task, BIO.Par[Throwable, ?]].parallel[Int, Int]
   }
 
- checkAllAsync("Monoid[BIO[Throwable, Int]]") { implicit ec =>
-   MonoidTests[BIO[Throwable, Int]].monoid
- }
+  checkAllAsync("Monoid[BIO[Throwable, Int]]") { implicit ec =>
+    MonoidTests[BIO[Throwable, Int]].monoid
+  }
 
   checkAllAsync("SemigroupK[Task[Int]]") { implicit ec =>
     SemigroupKTests[Task].semigroupK[Int]

--- a/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskWithCallbackSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskWithCallbackSuite.scala
@@ -18,9 +18,9 @@
 package monix.bio
 
 import cats.effect.laws.discipline.{ConcurrentEffectTests, ConcurrentTests}
-import cats.laws.discipline.{CoflatMapTests, ParallelTests, ApplicativeTests, BifunctorTests}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests}
 import cats.kernel.laws.discipline.MonoidTests
-import cats.{Eq, Applicative}
+import cats.{Applicative, Eq}
 import monix.bio.BIO.Options
 import monix.bio.instances.CatsParallelForTask
 import monix.bio.internal.TaskRunLoop.WrappedException
@@ -118,9 +118,9 @@ class BaseTypeClassLawsForTaskWithCallbackSuite(implicit opts: BIO.Options) exte
     ParallelTests[Task, BIO.Par[Throwable, ?]].parallel[Int, Int]
   }
 
- checkAllAsync("Monoid[BIO[Throwable, Int]]") { implicit ec =>
-   MonoidTests[BIO[Throwable, Int]].monoid
- }
+  checkAllAsync("Monoid[BIO[Throwable, Int]]") { implicit ec =>
+    MonoidTests[BIO[Throwable, Int]].monoid
+  }
 
   checkAllAsync("Bifunctor[BIO[String, Int]]") { implicit ec =>
     BifunctorTests[BIO].bifunctor[String, String, String, Int, Int, Int]

--- a/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskWithCallbackSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TypeClassLawsForTaskWithCallbackSuite.scala
@@ -18,8 +18,8 @@
 package monix.bio
 
 import cats.effect.laws.discipline.{ConcurrentEffectTests, ConcurrentTests}
-import cats.laws.discipline.{CoflatMapTests, ParallelTests, ApplicativeTests, BifunctorTests}
-import cats.{Eq, Applicative}
+import cats.laws.discipline.{ApplicativeTests, BifunctorTests, CoflatMapTests, ParallelTests}
+import cats.{Applicative, Eq}
 import monix.bio.BIO.Options
 import monix.bio.instances.CatsParallelForTask
 import monix.bio.internal.TaskRunLoop.WrappedException


### PR DESCRIPTION
Fixes a bugs with `UIO.eval` and `BIO.suspend` which caused to return a `Throwable` in typed error channel even if it was a different type

I was thinking about different names but I didn't come up with anything very compelling so I went with consistency with ZIO