### PR TITLE
Remove try-catch for RejectedExecutionException from most operators

### DIFF
--- a/core/jvm/src/test/scala/monix/bio/TaskRejectedExecutionSuite.scala
+++ b/core/jvm/src/test/scala/monix/bio/TaskRejectedExecutionSuite.scala
@@ -50,5 +50,6 @@ object TaskRejectedExecutionSuite extends SimpleTestSuite {
     testRejected(Task.shift(limited))
     testRejected(Task.pure(0).asyncBoundary(limited))
     testRejected(Task.pure(0).executeOn(limited))
+    testRejected(Task.async0[Unit]((_, cb) => global.executeAsync(() => cb.onSuccess(()))))
   }
 }

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -2175,6 +2175,7 @@ sealed abstract class BIO[+E, +A] extends Serializable {
   override def toString: String = this match {
     case Now(a) => s"BIO.Now($a)"
     case Error(e) => s"BIO.Error($e)"
+    case FatalError(e) => s"BIO.FatalError($e)"
     case _ =>
       val n = this.getClass.getName.replaceFirst("^monix\\.bio\\.BIO[$.]", "")
       s"BIO.$n$$${System.identityHashCode(this)}"

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -28,32 +28,32 @@ import scala.concurrent.duration.FiniteDuration
 object UIO {
 
   /**
-   * @see See [[monix.bio.BIO.apply]]
-   */
+    * @see See [[monix.bio.BIO.apply]]
+    */
   def apply[A](a: => A): UIO[A] =
     BIO.EvalTotal(a _)
 
   /**
-   * @see See [[monix.bio.BIO.now]]
-   */
+    * @see See [[monix.bio.BIO.now]]
+    */
   def now[A](a: A): UIO[A] =
     BIO.now(a)
 
   /**
-   * @see See [[monix.bio.BIO.pure]]
-   */
+    * @see See [[monix.bio.BIO.pure]]
+    */
   def pure[A](a: A): UIO[A] =
     BIO.pure(a)
 
   /**
-   * @see See [[monix.bio.BIO.raiseFatalError]]
-   */
+    * @see See [[monix.bio.BIO.raiseFatalError]]
+    */
   def raiseFatalError(ex: Throwable): UIO[Nothing] =
     BIO.raiseFatalError(ex)
 
   /**
-   * @see See [[monix.bio.BIO.defer]]
-   */
+    * @see See [[monix.bio.BIO.defer]]
+    */
   def defer[A](fa: => UIO[A]): UIO[A] =
     BIO.deferTotal(fa)
 
@@ -64,14 +64,14 @@ object UIO {
     BIO.deferTotal(fa)
 
   /**
-   * @see See [[monix.bio.BIO.deferAction]]
-   */
+    * @see See [[monix.bio.BIO.deferAction]]
+    */
   def deferAction[A](f: Scheduler => UIO[A]): UIO[A] =
     BIO.deferAction(f)
 
   /**
-   * @see See [[monix.bio.BIO.suspend]]
-   */
+    * @see See [[monix.bio.BIO.suspend]]
+    */
   def suspend[A](fa: => UIO[A]): UIO[A] =
     BIO.suspendTotal(fa)
 
@@ -82,8 +82,8 @@ object UIO {
     BIO.suspendTotal(fa)
 
   /**
-   * @see See [[monix.bio.BIO.eval]]
-   */
+    * @see See [[monix.bio.BIO.eval]]
+    */
   def eval[A](a: => A): UIO[A] =
     BIO.EvalTotal(a _)
 
@@ -94,107 +94,107 @@ object UIO {
     BIO.EvalTotal(a _)
 
   /**
-   * @see See [[monix.bio.BIO.evalAsync]]
-   */
+    * @see See [[monix.bio.BIO.evalAsync]]
+    */
   def evalAsync[A](a: => A): UIO[A] =
     BIO.EvalTotal(a _).executeAsync
 
   /**
-   * @see See [[monix.bio.BIO.delay]]
-   */
+    * @see See [[monix.bio.BIO.delay]]
+    */
   def delay[A](a: => A): UIO[A] =
     eval(a)
 
   /**
-   * @see See [[monix.bio.BIO.never]]
-   */
+    * @see See [[monix.bio.BIO.never]]
+    */
   val never: UIO[Nothing] =
     BIO.never
 
   /**
-   * @see See [[monix.bio.BIO.tailRecM]]
-   */
+    * @see See [[monix.bio.BIO.tailRecM]]
+    */
   def tailRecM[A, B](a: A)(f: A => UIO[Either[A, B]]): UIO[B] =
     defer(f(a)).flatMap {
       case Left(continueA) => tailRecM(continueA)(f)
-      case Right(b)        => now(b)
+      case Right(b) => now(b)
     }
 
   /**
-   * @see See [[monix.bio.BIO.unit]]
-   */
+    * @see See [[monix.bio.BIO.unit]]
+    */
   val unit: UIO[Unit] =
     BIO.unit
 
   /**
-   * @see See [[monix.bio.BIO.cancelBoundary]]
-   */
+    * @see See [[monix.bio.BIO.cancelBoundary]]
+    */
   val cancelBoundary: UIO[Unit] =
     BIO.cancelBoundary
 
   /**
-   * @see See [[monix.bio.BIO.race]]
-   */
+    * @see See [[monix.bio.BIO.race]]
+    */
   def race[A, B](fa: UIO[A], fb: UIO[B]): UIO[Either[A, B]] =
     TaskRace(fa, fb)
 
   /**
-   * @see See [[monix.bio.BIO.racePair]]
-   */
+    * @see See [[monix.bio.BIO.racePair]]
+    */
   def racePair[A, B](fa: UIO[A], fb: UIO[B]): UIO[Either[(A, Fiber[Nothing, B]), (Fiber[Nothing, A], B)]] =
     TaskRacePair(fa, fb)
 
   /**
-   * @see See [[monix.bio.BIO.shift]]
-   */
+    * @see See [[monix.bio.BIO.shift]]
+    */
   val shift: UIO[Unit] =
     BIO.shift
 
   /**
-   * @see See [[monix.bio.BIO.shift]]
-   */
+    * @see See [[monix.bio.BIO.shift]]
+    */
   def shift(ec: ExecutionContext): UIO[Unit] =
     BIO.shift(ec)
 
   /**
-   * @see See [[monix.bio.BIO.sleep]]
-   */
+    * @see See [[monix.bio.BIO.sleep]]
+    */
   def sleep(timespan: FiniteDuration): UIO[Unit] =
     BIO.sleep(timespan)
 
   /**
-   * @see See [[monix.bio.BIO.sequence]]
-   */
+    * @see See [[monix.bio.BIO.sequence]]
+    */
   def sequence[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] =
     TaskSequence.list[Nothing, A, M](in)(bf)
 
   /**
-   * @see See [[monix.bio.BIO.traverse]]
-   */
+    * @see See [[monix.bio.BIO.traverse]]
+    */
   def traverse[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] =
     TaskSequence.traverse(in, f)(bf)
 
   /**
-   * @see See [[monix.bio.BIO.gather]]
-   */
+    * @see See [[monix.bio.BIO.gather]]
+    */
   def gather[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] =
     TaskGather[Nothing, A, M](in, () => newBuilder(bf, in))
 
   /**
-   * @see See [[monix.bio.BIO.gatherN]]
-   */
+    * @see See [[monix.bio.BIO.gatherN]]
+    */
   def gatherN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] =
     TaskGatherN[Nothing, A](parallelism, in)
 
   /**
-   * @see See [[monix.bio.BIO.gatherUnordered]]
-   */
+    * @see See [[monix.bio.BIO.gatherUnordered]]
+    */
   def gatherUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] =
     TaskGatherUnordered[Nothing, A](in)
 
   /**
-   * @see See [[monix.bio.BIO.mapBoth]]
-   */
+    * @see See [[monix.bio.BIO.mapBoth]]
+    */
   def mapBoth[A1, A2, R](fa1: UIO[A1], fa2: UIO[A2])(f: (A1, A2) => R): UIO[R] =
     TaskMapBoth(fa1, fa2)(f)
 }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskMemoize.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskMemoize.scala
@@ -47,7 +47,8 @@ private[bio] object TaskMemoize {
           new Register(source, cacheErrors),
           trampolineBefore = false,
           trampolineAfter = true,
-          restoreLocals = true)
+          restoreLocals = true
+        )
     }
 
   /** Registration function, used in `Task.Async`. */
@@ -128,7 +129,8 @@ private[bio] object TaskMemoize {
       * that will receive the result once the task is complete.
       */
     private def registerListener(p: Promise[Either[E, A]], context: Context[E], cb: BiCallback[E, A])(
-      implicit ec: ExecutionContext): Unit = {
+      implicit ec: ExecutionContext
+    ): Unit = {
 
       p.future.onComplete { r =>
         // Listener is cancelable: we simply ensure that the result isn't streamed

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRestartCallback.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRestartCallback.scala
@@ -17,8 +17,6 @@
 
 package monix.bio.internal
 
-import java.util.concurrent.RejectedExecutionException
-
 import monix.bio.BIO
 import monix.bio.BIO.{Context, Error, FatalError, Now}
 import monix.bio.internal.TaskRunLoop.{startFull, Bind, CallStack, WrappedException}
@@ -61,8 +59,9 @@ private[internal] abstract class TaskRestartCallback(contextInit: Context[Any], 
     } else {
       try task.register(context, this)
       catch {
+        // Due to C-E law: ConcurrentEffect[Task].concurrentEffect.repeated callback ignored
+        // but we don't want to lose any errors
         case cbError: CallbackCalledMultipleTimesException => context.scheduler.reportFailure(cbError)
-        case r: RejectedExecutionException => onFatalError(r)
         case NonFatal(e) => onFatalError(e)
       }
     }
@@ -109,7 +108,7 @@ private[internal] abstract class TaskRestartCallback(contextInit: Context[Any], 
       }
     } else {
       // $COVERAGE-OFF$
-      context.scheduler.reportFailure(WrappedException.wrap(error))
+      context.scheduler.reportFailure(error)
       // $COVERAGE-ON$
     }
   }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskShift.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskShift.scala
@@ -17,8 +17,6 @@
 
 package monix.bio.internal
 
-import java.util.concurrent.RejectedExecutionException
-
 import monix.bio.BIO.{Async, Context}
 import monix.bio.UIO
 import monix.execution.Scheduler
@@ -62,17 +60,12 @@ private[bio] object TaskShift {
           ec
         }
 
-      try {
-        ec2.execute(new Runnable {
-          def run(): Unit = {
-            context.frameRef.reset()
-            cb.onSuccess(())
-          }
-        })
-      } catch {
-        case e: RejectedExecutionException =>
-          cb.onFatalError(e)
-      }
+      ec2.execute(new Runnable {
+        def run(): Unit = {
+          context.frameRef.reset()
+          cb.onSuccess(())
+        }
+      })
     }
   }
 }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskSleep.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskSleep.scala
@@ -17,8 +17,6 @@
 
 package monix.bio.internal
 
-import java.util.concurrent.RejectedExecutionException
-
 import monix.bio.BIO.{Async, Context}
 import monix.bio.UIO
 
@@ -46,16 +44,12 @@ private[bio] object TaskSleep {
       val c = TaskConnectionRef[Nothing]()
       ctx.connection.push(c.cancel)
 
-      try {
-        c := ctx.scheduler.scheduleOnce(
-          timespan.length,
-          timespan.unit,
-          new SleepRunnable(ctx, cb)
-        )
-      } catch {
-        case e: RejectedExecutionException =>
-          cb.onFatalError(e)
-      }
+      c := ctx.scheduler.scheduleOnce(
+        timespan.length,
+        timespan.unit,
+        new SleepRunnable(ctx, cb)
+      )
+
     }
   }
 

--- a/core/shared/src/test/scala/monix/bio/TaskToStringSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskToStringSuite.scala
@@ -47,6 +47,11 @@ object TaskToStringSuite extends SimpleTestSuite {
     assertContains(ref, "BIO.Eval")
   }
 
+  test("BIO.EvalTotal") {
+    val ref = BIO.evalTotal("hello")
+    assertContains(ref, "BIO.EvalTotal")
+  }
+
   test("BIO.Async") {
     val ref = BIO.cancelable0[Int, Int]((_, cb) => { cb.onSuccess(1); BIO.unit })
     assertContains(ref, "BIO.Async")
@@ -60,6 +65,11 @@ object TaskToStringSuite extends SimpleTestSuite {
   test("BIO.Suspend") {
     val ref = Task.defer(BIO.now(1))
     assertContains(ref, "BIO.Suspend")
+  }
+
+  test("BIO.SuspendTotal") {
+    val ref = BIO.suspendTotal(BIO.now(1))
+    assertContains(ref, "BIO.SuspendTotal")
   }
 
   test("BIO.Map") {


### PR DESCRIPTION
It should be already intercepted by `TaskRestartCallback` 