### PR TITLE
Refactor Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ I'm happy to guide anyone interested in contributing. Just let me know on specif
 ## Short introduction
 
 `BIO[E, A]` represents a specification for a possibly lazy or asynchronous computation, which when executed will produce
-a successful value `A`, an error `E`, never terminate or complete with a fatal error.
+a successful value `A`, an error `E`, never terminate or complete with a terminal (untyped) error.
 
 It composes very well and can handle many use cases such as cancellation, resource safety, context propagation, error handling or parallelism.
 

--- a/core/jvm/src/test/scala/monix/bio/TaskAsyncAutoShiftJVMSuite.scala
+++ b/core/jvm/src/test/scala/monix/bio/TaskAsyncAutoShiftJVMSuite.scala
@@ -961,7 +961,7 @@ object TaskAsyncAutoShiftJVMSuite extends TestSuite[SchedulerService] {
       .async0[Nothing, Int]((s, cb) => s.executeAsync(() => cb.onSuccess(1)))
       .executeOn(s2)
       .redeem(_ => 2, identity)
-      .redeemFatal(_ => 3, identity)
+      .redeemCause(_ => 3, identity)
       .runToFuture(s)
 
     for (result <- f) yield {

--- a/core/jvm/src/test/scala/monix/bio/TaskCallbackSafetyJVMSuite.scala
+++ b/core/jvm/src/test/scala/monix/bio/TaskCallbackSafetyJVMSuite.scala
@@ -20,9 +20,10 @@ package monix.bio
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import minitest.SimpleTestSuite
+import monix.bio.internal.BiCallback
 import monix.execution.exceptions.{CallbackCalledMultipleTimesException, DummyException}
 import monix.execution.schedulers.SchedulerService
-import monix.execution.{Callback, Scheduler}
+import monix.execution.Scheduler
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -36,36 +37,36 @@ object TaskCallbackSafetyJVMSuite extends SimpleTestSuite {
   val WORKERS = 10
   val RETRIES = if (!isTravis) 1000 else 100
 
-  test("Task.async has a safe callback") {
-    runConcurrentCallbackTest(Task.async)
+  test("BIO.async has a safe callback") {
+    runConcurrentCallbackTest(BIO.async)
   }
 
-  test("Task.async0 has a safe callback") {
-    runConcurrentCallbackTest(f => Task.async0((_, cb) => f(cb)))
+  test("BIO.async0 has a safe callback") {
+    runConcurrentCallbackTest(f => BIO.async0((_, cb) => f(cb)))
   }
 
-  test("Task.asyncF has a safe callback") {
-    runConcurrentCallbackTest(f => Task.asyncF(cb => Task(f(cb))))
+  test("BIO.asyncF has a safe callback") {
+    runConcurrentCallbackTest(f => BIO.asyncF(cb => BIO.evalTotal(f(cb))))
   }
 
-  test("Task.cancelable has a safe callback") {
+  test("BIO.cancelable has a safe callback") {
     runConcurrentCallbackTest(f =>
-      Task.cancelable { cb =>
-        f(cb); Task(())
+      BIO.cancelable[String, Int] { cb =>
+        f(cb); BIO.evalTotal(())
       }
     )
   }
 
-  test("Task.cancelable0 has a safe callback") {
+  test("BIO.cancelable0 has a safe callback") {
     runConcurrentCallbackTest(f =>
-      Task.cancelable0 { (_, cb) =>
-        f(cb); Task(())
+      BIO.cancelable0[String, Int] { (_, cb) =>
+        f(cb); BIO.evalTotal(())
       }
     )
   }
 
-  def runConcurrentCallbackTest(create: (Callback[Throwable, Int] => Unit) => Task[Int]): Unit = {
-    def run(trigger: Callback[Throwable, Int] => Unit): Unit = {
+  def runConcurrentCallbackTest(create: (BiCallback[String, Int] => Unit) => BIO[String, Int]): Unit = {
+    def run(trigger: BiCallback[String, Int] => Unit): Unit = {
       implicit val sc: SchedulerService = Scheduler.io("task-callback-safety")
       try {
         for (_ <- 0 until RETRIES) {
@@ -95,7 +96,7 @@ object TaskCallbackSafetyJVMSuite extends SimpleTestSuite {
 
     run(_.tryOnSuccess(1))
     run(_.tryApply(Right(1)))
-    run(_.tryApply(Success(1)))
+    run(_.tryApply(Success(Right(1))))
 
     run { cb =>
       try cb.onSuccess(1)
@@ -106,22 +107,33 @@ object TaskCallbackSafetyJVMSuite extends SimpleTestSuite {
       catch { case _: CallbackCalledMultipleTimesException => () }
     }
     run { cb =>
-      try cb(Success(1))
+      try cb(Success(Right(1)))
       catch { case _: CallbackCalledMultipleTimesException => () }
     }
 
+    val dummyMsg = "dummy"
     val dummy = DummyException("dummy")
 
-    run(_.tryOnError(dummy))
-    run(_.tryApply(Left(dummy)))
+    run(_.tryOnError(dummyMsg))
+    run(_.tryOnTermination(dummy))
+    run(_.tryApply(Left(dummyMsg)))
+    run(_.tryApply(Success(Left(dummyMsg))))
     run(_.tryApply(Failure(dummy)))
 
     run { cb =>
-      try cb.onError(dummy)
+      try cb.onError(dummyMsg)
       catch { case _: CallbackCalledMultipleTimesException => () }
     }
     run { cb =>
-      try cb(Left(dummy))
+      try cb.onTermination(dummy)
+      catch { case _: CallbackCalledMultipleTimesException => () }
+    }
+    run { cb =>
+      try cb(Left(dummyMsg))
+      catch { case _: CallbackCalledMultipleTimesException => () }
+    }
+    run { cb =>
+      try cb(Success(Left(dummyMsg)))
       catch { case _: CallbackCalledMultipleTimesException => () }
     }
     run { cb =>

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -4177,8 +4177,8 @@ object BIO extends TaskInstancesLevel0 {
   private final class RedeemFatal[E, A, B](fe: Cause[E] => B, fs: A => B)
       extends StackFrame.FatalStackFrame[E, A, UIO[B]] {
     override def apply(a: A): UIO[B] = new Now(fs(a))
-    override def recover(e: E): UIO[B] = new Now(fe(Cause.typed(e)))
-    override def recoverFatal(e: Throwable): UIO[B] = new Now(fe(Cause.terminate(e)))
+    override def recover(e: E): UIO[B] = new Now(fe(Cause.Error(e)))
+    override def recoverFatal(e: Throwable): UIO[B] = new Now(fe(Cause.Termination(e)))
   }
 
   /** Used as optimization by [[BIO.attempt]]. */

--- a/core/shared/src/main/scala/monix/bio/Cause.scala
+++ b/core/shared/src/main/scala/monix/bio/Cause.scala
@@ -27,15 +27,11 @@ sealed abstract class Cause[+E] extends Product with Serializable {
       case Cause.Termination(value) => fa(value)
     }
 
-  def flatten(implicit E: E <:< Throwable): Throwable =
+  def toThrowable(implicit E: E <:< Throwable): Throwable =
     fold(identity, e => E(e))
 }
 
 object Cause {
-  def terminate(t: Throwable): Cause[Nothing] = Termination(t)
-
-  def typed[E](e: E): Cause[E] = Error(e)
-
   final case class Error[+E](value: E) extends Cause[E]
 
   final case class Termination(value: Throwable) extends Cause[Nothing]

--- a/core/shared/src/main/scala/monix/bio/Cause.scala
+++ b/core/shared/src/main/scala/monix/bio/Cause.scala
@@ -19,26 +19,24 @@ package monix.bio
 
 /** Represent a complete cause of the failed Task
   * exposing both typed and untyped error channel.
-  *
-  * Left means a fatal (untyped) error.
-  * Right means a typed error.
-  *
-  * WARNING: This one will change for sure. Currently I'm considering different options
-  * on how to report errors when there is a need to handle both cases or when
-  * there was more than one error at once.
   */
-final case class Cause[+E](value: Either[Throwable, E]) extends AnyVal {
+sealed abstract class Cause[+E] extends Product with Serializable {
+  def fold[B](fa: Throwable => B, fb: E => B): B =
+    this match {
+      case Cause.Error(value) => fb(value)
+      case Cause.Termination(value) => fa(value)
+    }
 
   def flatten(implicit E: E <:< Throwable): Throwable =
-    value.fold(identity, e => E(e))
-
-  def fold[C](fa: Throwable => C, fb: E => C): C =
-    value.fold(fa, fb)
+    fold(identity, e => E(e))
 }
 
 object Cause {
-  def fatal(t: Throwable): Cause[Nothing] = Cause(Left(t))
+  def terminate(t: Throwable): Cause[Nothing] = Termination(t)
 
-  def typed[E](e: E): Cause[E] =
-    Cause(Right(e))
+  def typed[E](e: E): Cause[E] = Error(e)
+
+  final case class Error[+E](value: E) extends Cause[E]
+
+  final case class Termination(value: Throwable) extends Cause[Nothing]
 }

--- a/core/shared/src/main/scala/monix/bio/Task.scala
+++ b/core/shared/src/main/scala/monix/bio/Task.scala
@@ -55,10 +55,10 @@ object Task {
     BIO.raiseError(ex)
 
   /**
-    * @see See [[monix.bio.BIO.raiseFatalError]]
+    * @see See [[monix.bio.BIO.terminate]]
     */
-  def raiseFatalError[A](ex: Throwable): Task[A] =
-    BIO.raiseFatalError(ex)
+  def terminate[A](ex: Throwable): Task[A] =
+    BIO.terminate(ex)
 
   /**
     * @see See [[monix.bio.BIO.defer]]

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -46,10 +46,10 @@ object UIO {
     BIO.pure(a)
 
   /**
-    * @see See [[monix.bio.BIO.raiseFatalError]]
+    * @see See [[monix.bio.BIO.terminate]]
     */
-  def raiseFatalError(ex: Throwable): UIO[Nothing] =
-    BIO.raiseFatalError(ex)
+  def terminate(ex: Throwable): UIO[Nothing] =
+    BIO.terminate(ex)
 
   /**
     * @see See [[monix.bio.BIO.defer]]

--- a/core/shared/src/main/scala/monix/bio/instances/CatsConcurrentForTask.scala
+++ b/core/shared/src/main/scala/monix/bio/instances/CatsConcurrentForTask.scala
@@ -43,21 +43,21 @@ class CatsAsyncForTask extends CatsBaseForTask[Throwable] with Async[Task] {
     TaskCreate.async(k)
 
   override def bracket[A, B](acquire: Task[A])(use: A => Task[B])(release: A => Task[Unit]): Task[B] =
-    acquire.bracket(use)(release.andThen(_.onErrorHandleWith(BIO.raiseFatalError)))
+    acquire.bracket(use)(release.andThen(_.onErrorHandleWith(BIO.terminate)))
 
   override def bracketCase[A, B](
     acquire: Task[A]
   )(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
-    acquire.bracketCase(use)((a, exit) => release(a, exitCaseFromCause(exit)).onErrorHandleWith(BIO.raiseFatalError))
+    acquire.bracketCase(use)((a, exit) => release(a, exitCaseFromCause(exit)).onErrorHandleWith(BIO.terminate))
 
   override def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
     TaskCreate.asyncF(k)
 
   override def guarantee[A](acquire: Task[A])(finalizer: Task[Unit]): Task[A] =
-    acquire.guarantee(finalizer.onErrorHandleWith(BIO.raiseFatalError))
+    acquire.guarantee(finalizer.onErrorHandleWith(BIO.terminate))
 
   override def guaranteeCase[A](acquire: Task[A])(finalizer: ExitCase[Throwable] => Task[Unit]): Task[A] =
-    acquire.guaranteeCase(exit => finalizer(exitCaseFromCause(exit)).onErrorHandleWith(BIO.raiseFatalError))
+    acquire.guaranteeCase(exit => finalizer(exitCaseFromCause(exit)).onErrorHandleWith(BIO.terminate))
 }
 
 /** Cats type class instance of [[monix.bio.BIO BIO]]

--- a/core/shared/src/main/scala/monix/bio/instances/package.scala
+++ b/core/shared/src/main/scala/monix/bio/instances/package.scala
@@ -23,7 +23,7 @@ package object instances {
 
   @inline private[instances] final def exitCaseFromCause(exit: ExitCase[Cause[Throwable]]): ExitCase[Throwable] =
     exit match {
-      case ExitCase.Error(e) => ExitCase.Error(e.flatten)
+      case ExitCase.Error(e) => ExitCase.Error(e.toThrowable)
       case ExitCase.Completed => ExitCase.Completed
       case ExitCase.Canceled => ExitCase.Canceled
     }

--- a/core/shared/src/main/scala/monix/bio/internal/StackFrame.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/StackFrame.scala
@@ -59,8 +59,8 @@ private[bio] object StackFrame {
   final class RedeemFatalWith[E, -A, +R](fe: Cause[E] => R, fa: A => R) extends FatalStackFrame[E, A, R] {
     override def apply(a: A): R = fa(a)
 
-    override def recover(e: E): R = fe(Cause.typed(e))
+    override def recover(e: E): R = fe(Cause.Error(e))
 
-    override def recoverFatal(e: Throwable): R = fe(Cause.terminate(e))
+    override def recoverFatal(e: Throwable): R = fe(Cause.Termination(e))
   }
 }

--- a/core/shared/src/main/scala/monix/bio/internal/StackFrame.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/StackFrame.scala
@@ -17,6 +17,8 @@
 
 package monix.bio.internal
 
+import monix.bio.Cause
+
 /** A mapping function type that is also able to handle errors.
   *
   * Used in the `Task` and `Coeval` implementations to specify
@@ -27,8 +29,6 @@ private[bio] abstract class StackFrame[E, -A, +R] extends (A => R) { self =>
   def apply(a: A): R
   def recover(e: E): R
 }
-
-// TODO: maybe add recoverFatal to StackFrame itself and throw when it's not possible?
 
 private[bio] object StackFrame {
 
@@ -48,17 +48,19 @@ private[bio] object StackFrame {
     def recover(e: E): R = fe(e)
   }
 
+  /** [[StackFrame]] for terminal errors.
+    */
   abstract class FatalStackFrame[E, -A, +R] extends StackFrame[E, A, R] {
     def apply(a: A): R
     def recover(e: E): R
     def recoverFatal(e: Throwable): R
   }
 
-  final class RedeemFatalWith[-A, +R](fe: Throwable => R, fa: A => R) extends FatalStackFrame[Throwable, A, R] {
+  final class RedeemFatalWith[E, -A, +R](fe: Cause[E] => R, fa: A => R) extends FatalStackFrame[E, A, R] {
     override def apply(a: A): R = fa(a)
 
-    override def recover(e: Throwable): R = fe(e)
+    override def recover(e: E): R = fe(Cause.typed(e))
 
-    override def recoverFatal(e: Throwable): R = fe(e)
+    override def recoverFatal(e: Throwable): R = fe(Cause.terminate(e))
   }
 }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskBracket.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskBracket.scala
@@ -278,7 +278,7 @@ private[monix] object TaskBracket {
     private final def unsafeRecover(e: E): BIO[E, B] = {
       if (waitsForResult.compareAndSet(expect = true, update = false)) {
         ctx.connection.pop()
-        val cause = Cause.typed(e)
+        val cause = Cause.Error(e)
         releaseOnError(a, cause).flatMap[E, B](new ReleaseRecover(cause))
       } else {
         BIO.never
@@ -288,7 +288,7 @@ private[monix] object TaskBracket {
     private final def unsafeRecoverFatal(e: Throwable): BIO[E, B] = {
       if (waitsForResult.compareAndSet(expect = true, update = false)) {
         ctx.connection.pop()
-        val cause = Cause.terminate(e)
+        val cause = Cause.Termination(e)
         releaseOnError(a, cause).flatMap[E, B](new ReleaseRecover(cause))
       } else {
         BIO.never

--- a/core/shared/src/main/scala/monix/bio/internal/TaskCancellation.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskCancellation.scala
@@ -65,10 +65,10 @@ private[bio] object TaskCancellation {
 
     private[this] var value: A = _
     private[this] var error: E = _
-    private[this] var fatalError: Throwable = _
+    private[this] var terminalError: Throwable = _
 
     def run(): Unit = {
-      if (fatalError ne null) cb.onFatalError(fatalError)
+      if (terminalError ne null) cb.onTermination(terminalError)
       else if (error != null) cb.onError(error)
       else cb.onSuccess(value)
     }
@@ -89,10 +89,10 @@ private[bio] object TaskCancellation {
         s.reportFailure(UncaughtErrorException.wrap(e))
       }
 
-    override def onFatalError(e: Throwable): Unit =
+    override def onTermination(e: Throwable): Unit =
       if (waitsForResult.getAndSet(false)) {
         conn.pop()
-        this.fatalError = e
+        this.terminalError = e
         s.execute(this)
       } else {
         s.reportFailure(e)

--- a/core/shared/src/main/scala/monix/bio/internal/TaskConversions.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskConversions.scala
@@ -36,7 +36,7 @@ private[bio] object TaskConversions {
     source match {
       case BIO.Now(value) => IO.pure(value)
       case BIO.Error(e) => IO.raiseError(e)
-      case BIO.FatalError(e) => IO.raiseError(e)
+      case BIO.Termination(e) => IO.raiseError(e)
       case BIO.Eval(thunk) => IO(thunk())
       case BIO.EvalTotal(thunk) => IO(thunk())
       case _ =>
@@ -52,7 +52,7 @@ private[bio] object TaskConversions {
     source match {
       case BIO.Now(value) => F.pure(value)
       case BIO.Error(e) => F.raiseError(e)
-      case BIO.FatalError(e) => F.raiseError(e)
+      case BIO.Termination(e) => F.raiseError(e)
       case BIO.Eval(thunk) => F.delay(thunk())
       case BIO.EvalTotal(thunk) => F.delay(thunk())
       case _ =>
@@ -69,7 +69,7 @@ private[bio] object TaskConversions {
     source match {
       case BIO.Now(value) => F.pure(value)
       case BIO.Error(e) => F.raiseError(e)
-      case BIO.FatalError(e) => F.raiseError(e)
+      case BIO.Termination(e) => F.raiseError(e)
       case BIO.Eval(thunk) => F.delay(thunk())
       case BIO.EvalTotal(thunk) => F.delay(thunk())
       case _ => F.async(cb => eff.runAsync(source)(r => { cb(r); IO.unit }).unsafeRunSync())

--- a/core/shared/src/main/scala/monix/bio/internal/TaskEffect.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskEffect.scala
@@ -65,7 +65,7 @@ private[bio] object TaskEffect {
       override def onSuccess(value: A): Unit =
         signal(Right(value))
       override def onError(e: Cause[Throwable]): Unit = {
-        signal(Left(e.flatten))
+        signal(Left(e.toThrowable))
       }
     })
   }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskExecuteOn.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskExecuteOn.scala
@@ -54,7 +54,7 @@ private[bio] object TaskExecuteOn {
         new BiCallback[E, A] with Runnable {
           private[this] var value: A = _
           private[this] var error: E = _
-          private[this] var fatalError: Throwable = _
+          private[this] var terminalError: Throwable = _
 
           def onSuccess(value: A): Unit = {
             this.value = value
@@ -66,13 +66,13 @@ private[bio] object TaskExecuteOn {
             oldS.execute(this)
           }
 
-          override def onFatalError(e: Throwable): Unit = {
-            this.fatalError = e
+          override def onTermination(e: Throwable): Unit = {
+            this.terminalError = e
             oldS.execute(this)
           }
 
           def run() = {
-            if (fatalError ne null) cb.onFatalError(fatalError)
+            if (terminalError ne null) cb.onTermination(terminalError)
             else if (error != null) cb.onError(error)
             else cb.onSuccess(value)
           }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskMapBoth.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskMapBoth.scala
@@ -59,7 +59,7 @@ private[bio] object TaskMapBoth {
           // Both tasks completed by this point, so we don't need
           // to worry about the `state` being a `Stop`
           mainConn.pop()
-          cb.onFatalError(ex)
+          cb.onTermination(ex)
       }
     }
 
@@ -84,8 +84,8 @@ private[bio] object TaskMapBoth {
       }
     }
 
-    /* For signaling a fatal error. */
-    @tailrec def sendFatalError(
+    /* For signaling a terminal error. */
+    @tailrec def sendTermination(
       mainConn: TaskConnection[E],
       state: AtomicAny[AnyRef],
       cb: BiCallback[E, R],
@@ -100,10 +100,10 @@ private[bio] object TaskMapBoth {
           s.reportFailure(ex)
         case other =>
           if (!state.compareAndSet(other, Stop))
-            sendFatalError(mainConn, state, cb, ex)(s) // retry
+            sendTermination(mainConn, state, cb, ex)(s) // retry
           else {
             mainConn.pop().runAsyncAndForget
-            cb.onFatalError(ex)
+            cb.onTermination(ex)
           }
       }
     }
@@ -137,15 +137,15 @@ private[bio] object TaskMapBoth {
               case s @ Left(_) =>
                 // This task has triggered multiple onSuccess calls
                 // violating the protocol. Should never happen.
-                onFatalError(new IllegalStateException(s.toString))
+                onTermination(new IllegalStateException(s.toString))
             }
 
           def onError(ex: E): Unit = {
             sendError(mainConn, state, cb, ex)(s)
           }
 
-          override def onFatalError(e: Throwable): Unit =
-            sendFatalError(mainConn, state, cb, e)
+          override def onTermination(e: Throwable): Unit =
+            sendTermination(mainConn, state, cb, e)
         }
       )
 
@@ -165,15 +165,15 @@ private[bio] object TaskMapBoth {
               case s @ Right(_) =>
                 // This task has triggered multiple onSuccess calls
                 // violating the protocol. Should never happen.
-                onFatalError(new IllegalStateException(s.toString))
+                onTermination(new IllegalStateException(s.toString))
             }
 
           def onError(ex: E): Unit = {
             sendError(mainConn, state, cb, ex)(s)
           }
 
-          override def onFatalError(e: Throwable): Unit =
-            sendFatalError(mainConn, state, cb, e)
+          override def onTermination(e: Throwable): Unit =
+            sendTermination(mainConn, state, cb, e)
         }
       )
     }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskMemoize.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskMemoize.scala
@@ -17,7 +17,7 @@
 
 package monix.bio.internal
 
-import monix.bio.BIO.{Context, Error, FatalError, Now}
+import monix.bio.BIO.{Context, Error, Now, Termination}
 import monix.bio.internal.TaskRunLoop.startFull
 import monix.bio.BIO
 import monix.execution.Scheduler
@@ -33,7 +33,7 @@ private[bio] object TaskMemoize {
     */
   def apply[E, A](source: BIO[E, A], cacheErrors: Boolean): BIO[E, A] =
     source match {
-      case Now(_) | Error(_) | FatalError(_) =>
+      case Now(_) | Error(_) | Termination(_) =>
         source
 
 //      TODO: implement this optimization once `Coeval` is implemented
@@ -121,7 +121,7 @@ private[bio] object TaskMemoize {
         def onError(e: E): Unit =
           self.cacheValue(Success(Left(e)))
 
-        def onFatalError(ex: Throwable): Unit =
+        def onTermination(ex: Throwable): Unit =
           self.cacheValue(Failure(ex))
       }
 
@@ -180,7 +180,7 @@ private[bio] object TaskMemoize {
   }
 
   /**
-    * Separates success case from expected and fatal error case.
+    * Separates success case from expected and terminal error case.
     */
   private def isSuccess[E, A](result: Try[Either[E, A]]): Boolean = result match {
     case Success(Right(_)) => true

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRace.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRace.scala
@@ -73,11 +73,11 @@ private[bio] object TaskRace {
               sc.reportFailure(UncaughtErrorException.wrap(ex))
             }
 
-          override def onFatalError(e: Throwable): Unit =
+          override def onTermination(e: Throwable): Unit =
             if (isActive.getAndSet(false)) {
               conn.pop()
               connB.cancel.runAsyncAndForget
-              cb.onFatalError(e)
+              cb.onTermination(e)
             } else {
               sc.reportFailure(e)
             }
@@ -105,11 +105,11 @@ private[bio] object TaskRace {
               sc.reportFailure(UncaughtErrorException.wrap(ex))
             }
 
-          override def onFatalError(e: Throwable): Unit =
+          override def onTermination(e: Throwable): Unit =
             if (isActive.getAndSet(false)) {
               conn.pop()
               connA.cancel.runAsyncAndForget
-              cb.onFatalError(e)
+              cb.onTermination(e)
             } else {
               sc.reportFailure(e)
             }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskRacePair.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskRacePair.scala
@@ -82,11 +82,11 @@ private[bio] object TaskRacePair {
               pa.success(Left(ex))
             }
 
-          override def onFatalError(e: Throwable): Unit =
+          override def onTermination(e: Throwable): Unit =
             if (isActive.getAndSet(false)) {
               conn.pop()
               connB.cancel.runAsyncAndForget
-              cb.onFatalError(e)
+              cb.onTermination(e)
             } else {
               pa.failure(e)
             }
@@ -116,11 +116,11 @@ private[bio] object TaskRacePair {
               pb.success(Left(ex))
             }
 
-          override def onFatalError(e: Throwable): Unit =
+          override def onTermination(e: Throwable): Unit =
             if (isActive.getAndSet(false)) {
               conn.pop()
               connA.cancel.runAsyncAndForget
-              cb.onFatalError(e)
+              cb.onTermination(e)
             } else {
               pb.failure(e)
             }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskStart.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskStart.scala
@@ -29,7 +29,7 @@ private[bio] object TaskStart {
   def forked[E, A](fa: BIO[E, A]): UIO[Fiber[E, A]] =
     fa match {
       // There's no point in evaluating strict stuff
-      case BIO.Now(_) | BIO.Error(_) | BIO.FatalError(_) =>
+      case BIO.Now(_) | BIO.Error(_) | BIO.Termination(_) =>
         BIO.Now(Fiber(fa, BIO.unit))
       case _ =>
         Async[Nothing, Fiber[E, A]](

--- a/core/shared/src/main/scala/monix/bio/internal/TaskToReactivePublisher.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskToReactivePublisher.scala
@@ -59,7 +59,7 @@ private[bio] object TaskToReactivePublisher {
 
     private[this] var isActive = true
 
-    override def onFatalError(e: Throwable): Unit =
+    override def onTermination(e: Throwable): Unit =
       onError(e)
 
     override def onError(e: Throwable): Unit =

--- a/core/shared/src/test/scala/monix/bio/BaseLawsSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/BaseLawsSuite.scala
@@ -118,8 +118,8 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
     def genError: Gen[BIO[E, A]] =
       getArbitrary[E].map(BIO.raiseError)
 
-    def genFatalError: Gen[BIO[E, A]] =
-      getArbitrary[Throwable].map(BIO.raiseFatalError)
+    def genTerminate: Gen[BIO[E, A]] =
+      getArbitrary[Throwable].map(BIO.terminate)
 
     def genAsync: Gen[BIO[E, A]] =
       getArbitrary[(Either[E, A] => Unit) => Unit].map(TaskCreate.async)
@@ -146,7 +146,7 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
       1 -> genEval,
       1 -> genEvalAsync,
       1 -> genError,
-      1 -> genFatalError,
+      1 -> genTerminate,
       1 -> genAsync,
       1 -> genNestedAsync,
       1 -> genBindSuspend
@@ -182,7 +182,7 @@ trait ArbitraryInstancesBase extends monix.execution.ArbitraryInstances {
         1 -> genEvalAsync,
         1 -> genEval,
         1 -> genError,
-        1 -> genFatalError,
+        1 -> genTerminate,
         1 -> genContextSwitch,
         1 -> genCancelable,
         1 -> genBindSuspend,

--- a/core/shared/src/test/scala/monix/bio/TaskAsyncBoundarySuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskAsyncBoundarySuite.scala
@@ -22,10 +22,10 @@ import monix.execution.schedulers.TestScheduler
 import scala.util.Success
 
 object TaskAsyncBoundarySuite extends BaseTestSuite {
-  test("Task.asyncBoundary should work") { implicit s =>
+  test("BIO.asyncBoundary should work") { implicit s =>
     val io = TestScheduler()
     var effect = 0
-    val f = Task.eval { effect += 1; effect }
+    val f = UIO.eval { effect += 1; effect }
       .executeOn(io)
       .asyncBoundary
       .map(_ + 1)
@@ -43,12 +43,12 @@ object TaskAsyncBoundarySuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(2))))
   }
 
-  test("Task.asyncBoundary(other) should work") { implicit s1 =>
+  test("BIO.asyncBoundary(other) should work") { implicit s1 =>
     val io = TestScheduler()
     val s2 = TestScheduler()
 
     var effect = 0
-    val f = Task.eval { effect += 1; effect }
+    val f = UIO.eval { effect += 1; effect }
       .executeOn(io)
       .asyncBoundary(s2)
       .map(_ + 1)
@@ -68,7 +68,7 @@ object TaskAsyncBoundarySuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(2))))
   }
 
-  testAsync("Task.asyncBoundary should preserve locals") { _ =>
+  testAsync("BIO.asyncBoundary should preserve locals") { _ =>
     import monix.execution.Scheduler.Implicits.global
     implicit val opts = BIO.defaultOptions.enableLocalContextPropagation
 
@@ -83,7 +83,7 @@ object TaskAsyncBoundarySuite extends BaseTestSuite {
     }
   }
 
-  testAsync("Task.asyncBoundary(scheduler) should preserve locals") { _ =>
+  testAsync("BIO.asyncBoundary(scheduler) should preserve locals") { _ =>
     import monix.execution.Scheduler.Implicits.global
     implicit val opts = BIO.defaultOptions.enableLocalContextPropagation
 
@@ -98,26 +98,26 @@ object TaskAsyncBoundarySuite extends BaseTestSuite {
     }
   }
 
-  test("Task.asyncBoundary is stack safe in flatMap loops, test 1") { implicit sc =>
-    def loop(n: Int, acc: Long): Task[Long] =
-      Task.unit.asyncBoundary.flatMap { _ =>
+  test("BIO.asyncBoundary is stack safe in flatMap loops, test 1") { implicit sc =>
+    def loop(n: Int, acc: Long): UIO[Long] =
+      BIO.unit.asyncBoundary.flatMap { _ =>
         if (n > 0)
           loop(n - 1, acc + 1)
         else
-          Task.now(acc)
+          BIO.now(acc)
       }
 
     val f = loop(10000, 0).runToFuture; sc.tick()
     assertEquals(f.value, Some(Success(Right(10000))))
   }
 
-  test("Task.asyncBoundary is stack safe in flatMap loops, test 2") { implicit sc =>
-    def loop(n: Int, acc: Long): Task[Long] =
-      Task.unit.flatMap { _ =>
+  test("BIO.asyncBoundary is stack safe in flatMap loops, test 2") { implicit sc =>
+    def loop(n: Int, acc: Long): UIO[Long] =
+      BIO.unit.flatMap { _ =>
         if (n > 0)
           loop(n - 1, acc + 1).asyncBoundary
         else
-          Task.now(acc)
+          BIO.now(acc)
       }
 
     val f = loop(10000, 0).runToFuture

--- a/core/shared/src/test/scala/monix/bio/TaskBimapSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskBimapSuite.scala
@@ -17,22 +17,22 @@
 
 package monix.bio
 
-import monix.bio.BIO.{Error, Now}
-
 import scala.util.Success
 
 object TaskBimapSuite extends BaseTestSuite {
-  test("it should map the success channel") { implicit s =>
-    val f = Now(1)
-      .bimap(identity, _ => "Success")
+  test("BIO.bimap should map the success channel") { implicit s =>
+    val f = BIO
+      .now(1)
+      .bimap(_ => "Error", _ => "Success")
       .runToFuture
 
     assertEquals(f.value, Some(Success(Right("Success"))))
   }
 
-  test("it should map the error channel") { implicit s =>
-    val f = Error(1)
-      .bimap(_ => "Error", identity)
+  test("BIO.bimap should map the error channel") { implicit s =>
+    val f = BIO
+      .raiseError(1)
+      .bimap(_ => "Error", _ => "Success")
       .runToFuture
 
     assertEquals(f.value, Some(Success(Left("Error"))))

--- a/core/shared/src/test/scala/monix/bio/TaskBracketSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskBracketSuite.scala
@@ -75,7 +75,7 @@ object TaskBracketSuite extends BaseTestSuite {
     val f = task.runToFuture
     sc.tick()
 
-    assertEquals(input, Some((1, Left(Some(Cause.terminate(dummy))))))
+    assertEquals(input, Some((1, Left(Some(Cause.Termination(dummy))))))
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
@@ -103,7 +103,7 @@ object TaskBracketSuite extends BaseTestSuite {
     val f = task.runToFuture
     sc.tick()
 
-    assertEquals(input, Some((1, Left(Some(Cause.typed(-99))))))
+    assertEquals(input, Some((1, Left(Some(Cause.Error(-99))))))
     assertEquals(f.value, Some(Success(Left(-99))))
   }
 
@@ -118,7 +118,7 @@ object TaskBracketSuite extends BaseTestSuite {
     val f = task.runToFuture
     sc.tick()
 
-    assertEquals(input, Some((1, Left(Some(Cause.terminate(dummy))))))
+    assertEquals(input, Some((1, Left(Some(Cause.Termination(dummy))))))
     assertEquals(f.value, Some(Failure(dummy)))
   }
 

--- a/core/shared/src/test/scala/monix/bio/TaskBracketSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskBracketSuite.scala
@@ -29,18 +29,32 @@ object TaskBracketSuite extends BaseTestSuite {
     check2 { (task: BIO[String, Int], f: String => UIO[Unit]) =>
       val expected = task.onErrorHandleWith(e => f(e) >> BIO.raiseError(e))
       val received = task.bracketE(BIO.now) {
-        case (_, Left(Some(e))) => e.fold(BIO.raiseFatalError, f)
+        case (_, Left(Some(e))) => e.fold(BIO.terminate, f)
         case (_, _) => UIO.unit
       }
       received <-> expected
     }
   }
 
-  test("equivalence with flatMap + transformWith") { implicit sc =>
+  test("equivalence with flatMap + redeemWith") { implicit sc =>
     check3 { (acquire: BIO[Int, Int], f: Int => BIO[Int, Int], release: Int => UIO[Unit]) =>
       val expected = acquire.flatMap { a =>
         f(a).redeemWith(
           e => release(a) >> BIO.raiseError(e),
+          s => release(a) >> BIO.pure(s)
+        )
+      }
+
+      val received = acquire.bracket(f)(release)
+      received <-> expected
+    }
+  }
+
+  test("equivalence with flatMap + redeemCauseWith") { implicit sc =>
+    check3 { (acquire: BIO[Int, Int], f: Int => BIO[Int, Int], release: Int => UIO[Unit]) =>
+      val expected = acquire.flatMap { a =>
+        f(a).redeemCauseWith(
+          e => release(a) >> e.fold(BIO.terminate, BIO.raiseError),
           s => release(a) >> BIO.pure(s)
         )
       }
@@ -61,7 +75,7 @@ object TaskBracketSuite extends BaseTestSuite {
     val f = task.runToFuture
     sc.tick()
 
-    assertEquals(input, Some((1, Left(Some(Cause.fatal(dummy))))))
+    assertEquals(input, Some((1, Left(Some(Cause.terminate(dummy))))))
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
@@ -93,18 +107,18 @@ object TaskBracketSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(-99))))
   }
 
-  test("release is evaluated on fatal error") { implicit sc =>
+  test("release is evaluated on terminal error") { implicit sc =>
     val dummy = new DummyException("dummy")
     var input = Option.empty[(Int, Either[Option[Cause[Int]], Int])]
 
-    val task: BIO[Int, Int] = UIO.evalAsync(1).bracketE[Int, Int](_ => BIO.raiseFatalError(dummy)) { (a, i) =>
+    val task: BIO[Int, Int] = UIO.evalAsync(1).bracketE[Int, Int](_ => BIO.terminate(dummy)) { (a, i) =>
       UIO.eval { input = Some((a, i)) }
     }
 
     val f = task.runToFuture
     sc.tick()
 
-    assertEquals(input, Some((1, Left(Some(Cause.fatal(dummy))))))
+    assertEquals(input, Some((1, Left(Some(Cause.terminate(dummy))))))
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
@@ -137,7 +151,7 @@ object TaskBracketSuite extends BaseTestSuite {
       .bracket { _ =>
         Task.raiseError[Int](useError)
       } { _ =>
-        BIO.raiseFatalError(releaseError)
+        BIO.terminate(releaseError)
       }
 
     val f = task.runToFuture

--- a/core/shared/src/test/scala/monix/bio/TaskCallbackSafetySuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskCallbackSafetySuite.scala
@@ -17,107 +17,107 @@
 
 package monix.bio
 
-import monix.execution.Callback
+import monix.bio.internal.BiCallback
 import monix.execution.exceptions.CallbackCalledMultipleTimesException
 import monix.execution.schedulers.TestScheduler
 
 import scala.util.{Failure, Success}
 
 object TaskCallbackSafetySuite extends BaseTestSuite {
-  test("Task.async's callback can be called multiple times") { implicit sc =>
-    runTestCanCallMultipleTimes(Task.async)
+  test("BIO.async's callback can be called multiple times") { implicit sc =>
+    runTestCanCallMultipleTimes(BIO.async)
   }
 
-  test("Task.async0's callback can be called multiple times") { implicit sc =>
-    runTestCanCallMultipleTimes(r => Task.async0((_, cb) => r(cb)))
+  test("BIO.async0's callback can be called multiple times") { implicit sc =>
+    runTestCanCallMultipleTimes(r => BIO.async0((_, cb) => r(cb)))
   }
 
-  test("Task.asyncF's callback can be called multiple times") { implicit sc =>
-    runTestCanCallMultipleTimes(r => Task.asyncF(cb => Task(r(cb))))
+  test("BIO.asyncF's callback can be called multiple times") { implicit sc =>
+    runTestCanCallMultipleTimes(r => BIO.asyncF(cb => BIO.evalTotal(r(cb))))
   }
 
-  test("Task.cancelable's callback can be called multiple times") { implicit sc =>
+  test("BIO.cancelable's callback can be called multiple times") { implicit sc =>
     runTestCanCallMultipleTimes(r =>
-      Task.cancelable { cb =>
-        r(cb); Task.unit
+      BIO.cancelable[Int, Int] { cb =>
+        r(cb); BIO.unit
       }
     )
   }
 
-  test("Task.cancelable0's callback can be called multiple times") { implicit sc =>
+  test("BIO.cancelable0's callback can be called multiple times") { implicit sc =>
     runTestCanCallMultipleTimes(r =>
-      Task.cancelable0 { (_, cb) =>
-        r(cb); Task.unit
+      BIO.cancelable0[Int, Int] { (_, cb) =>
+        r(cb); BIO.unit
       }
     )
   }
 
-  test("Task.async's register throwing is signaled as error") { implicit sc =>
-    runTestRegisterCanThrow(Task.async)
+  test("BIO.async's register throwing is signaled as error") { implicit sc =>
+    runTestRegisterCanThrow(BIO.async)
   }
 
-  test("Task.async0's register throwing is signaled as error") { implicit sc =>
-    runTestRegisterCanThrow(r => Task.async0((_, cb) => r(cb)))
+  test("BIO.async0's register throwing is signaled as error") { implicit sc =>
+    runTestRegisterCanThrow(r => BIO.async0((_, cb) => r(cb)))
   }
 
-  test("Task.asyncF's register throwing is signaled as error (1)") { implicit sc =>
-    runTestRegisterCanThrow(r => Task.asyncF(cb => Task(r(cb))))
+  test("BIO.asyncF's register throwing is signaled as error (1)") { implicit sc =>
+    runTestRegisterCanThrow(r => BIO.asyncF(cb => BIO.evalTotal(r(cb))))
   }
 
-  test("Task.asyncF's register throwing is signaled as error (2)") { implicit sc =>
-    runTestRegisterCanThrow(r => Task.asyncF(cb => { r(cb); Task.unit }))
+  test("BIO.asyncF's register throwing is signaled as error (2)") { implicit sc =>
+    runTestRegisterCanThrow(r => BIO.asyncF(cb => { r(cb); BIO.unit }))
   }
 
-  test("Task.cancelable's register throwing is signaled as error") { implicit sc =>
+  test("BIO.cancelable's register throwing is signaled as error") { implicit sc =>
     runTestRegisterCanThrow(r =>
-      Task.cancelable { cb =>
-        r(cb); Task.unit
+      BIO.cancelable[Int, Int] { cb =>
+        r(cb); BIO.unit
       }
     )
   }
 
-  test("Task.cancelable0's register throwing is signaled as error") { implicit sc =>
+  test("BIO.cancelable0's register throwing is signaled as error") { implicit sc =>
     runTestRegisterCanThrow(r =>
-      Task.cancelable0 { (_, cb) =>
-        r(cb); Task.unit
+      BIO.cancelable0[Int, Int] { (_, cb) =>
+        r(cb); BIO.unit
       }
     )
   }
 
-  test("Task.async's register throwing, after result, is reported") { implicit sc =>
-    runTestRegisterThrowingCanBeReported(Task.async)
+  test("BIO.async's register throwing, after result, is reported") { implicit sc =>
+    runTestRegisterThrowingCanBeReported(BIO.async)
   }
 
-  test("Task.async0's register throwing, after result, is reported") { implicit sc =>
-    runTestRegisterThrowingCanBeReported(r => Task.async0((_, cb) => r(cb)))
+  test("BIO.async0's register throwing, after result, is reported") { implicit sc =>
+    runTestRegisterThrowingCanBeReported(r => BIO.async0((_, cb) => r(cb)))
   }
 
-  test("Task.asyncF's register throwing, after result, is reported (1)") { implicit sc =>
-    runTestRegisterThrowingCanBeReported(r => Task.asyncF(cb => Task(r(cb))))
+  test("BIO.asyncF's register throwing, after result, is reported (1)") { implicit sc =>
+    runTestRegisterThrowingCanBeReported(r => BIO.asyncF(cb => BIO.evalTotal(r(cb))))
   }
 
-  test("Task.asyncF's register throwing, after result, is reported (2)") { implicit sc =>
-    runTestRegisterThrowingCanBeReported(r => Task.asyncF(cb => { r(cb); Task.unit }))
+  test("BIO.asyncF's register throwing, after result, is reported (2)") { implicit sc =>
+    runTestRegisterThrowingCanBeReported(r => BIO.asyncF(cb => { r(cb); BIO.unit }))
   }
 
-  test("Task.cancelable's register throwing, after result, is reported") { implicit sc =>
+  test("BIO.cancelable's register throwing, after result, is reported") { implicit sc =>
     runTestRegisterThrowingCanBeReported(r =>
-      Task.cancelable { cb =>
-        r(cb); Task.unit
+      BIO.cancelable[Int, Int] { cb =>
+        r(cb); BIO.unit
       }
     )
   }
 
-  test("Task.cancelable0's register throwing, after result, is reported") { implicit sc =>
+  test("BIO.cancelable0's register throwing, after result, is reported") { implicit sc =>
     runTestRegisterThrowingCanBeReported(r =>
-      Task.cancelable0 { (_, cb) =>
-        r(cb); Task.unit
+      BIO.cancelable0[Int, Int] { (_, cb) =>
+        r(cb); BIO.unit
       }
     )
   }
 
   def runTestRegisterCanThrow(
-    create: (Callback[Throwable, Int] => Unit) => Task[Int]
+    create: (BiCallback[Int, Int] => Unit) => BIO[Int, Int]
   )(implicit sc: TestScheduler): Unit = {
 
     var effect = 0
@@ -127,10 +127,11 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
 
     task.runAsync {
       case Right(_) => ()
-      case Left(value) =>
-        value.fold(identity, identity) match {
+      case Left(Cause.Error(nr)) => effect += nr
+      case Left(Cause.Termination(ex)) =>
+        ex match {
           case WrappedEx(nr) => effect += nr
-          case e => throw e
+          case other => throw other
         }
     }
 
@@ -140,7 +141,7 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
   }
 
   def runTestRegisterThrowingCanBeReported(
-    create: (Callback[Throwable, Int] => Unit) => Task[Int]
+    create: (BiCallback[Int, Int] => Unit) => BIO[Int, Int]
   )(implicit sc: TestScheduler): Unit = {
 
     var effect = 0
@@ -151,10 +152,11 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
 
     task.runAsync {
       case Right(_) => effect += 1
-      case Left(value) =>
-        value.fold(identity, identity) match {
+      case Left(Cause.Error(nr)) => effect += nr
+      case Left(Cause.Termination(ex)) =>
+        ex match {
           case WrappedEx(nr) => effect += nr
-          case e => throw e
+          case other => throw other
         }
     }
 
@@ -164,10 +166,10 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
   }
 
   def runTestCanCallMultipleTimes(
-    create: (Callback[Throwable, Int] => Unit) => Task[Int]
+    create: (BiCallback[Int, Int] => Unit) => BIO[Int, Int]
   )(implicit sc: TestScheduler): Unit = {
 
-    def run(expected: Int)(trySignal: Callback[Throwable, Int] => Boolean) = {
+    def run(expected: Int)(trySignal: BiCallback[Int, Int] => Boolean) = {
       var effect = 0
       val task = create { cb =>
         assert(trySignal(cb))
@@ -177,10 +179,11 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
 
       task.runAsync {
         case Right(nr) => effect += nr
-        case Left(value) =>
-          value.fold(identity, identity) match {
+        case Left(Cause.Error(nr)) => effect += nr
+        case Left(Cause.Termination(ex)) =>
+          ex match {
             case WrappedEx(nr) => effect += nr
-            case e => throw e
+            case other => throw other
           }
       }
 
@@ -190,7 +193,7 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
     }
 
     run(1)(_.tryOnSuccess(1))
-    run(1)(_.tryApply(Success(1)))
+    run(1)(_.tryApply(Success(Right(1))))
     run(1)(_.tryApply(Right(1)))
 
     run(1)(cb =>
@@ -205,22 +208,28 @@ object TaskCallbackSafetySuite extends BaseTestSuite {
     )
     run(1)(cb =>
       try {
-        cb(Success(1)); true
+        cb(Success(Right(1))); true
       } catch { case _: CallbackCalledMultipleTimesException => false }
     )
 
-    run(10)(_.tryOnError(WrappedEx(10)))
+    run(10)(_.tryOnTermination(WrappedEx(10)))
+    run(10)(_.tryOnError(10))
     run(10)(_.tryApply(Failure(WrappedEx(10))))
-    run(10)(_.tryApply(Left(WrappedEx(10))))
+    run(10)(_.tryApply(Left(10)))
 
     run(10)(cb =>
       try {
-        cb.onError(WrappedEx(10)); true
+        cb.onTermination(WrappedEx(10)); true
       } catch { case _: CallbackCalledMultipleTimesException => false }
     )
     run(10)(cb =>
       try {
-        cb(Left(WrappedEx(10))); true
+        cb.onError(10); true
+      } catch { case _: CallbackCalledMultipleTimesException => false }
+    )
+    run(10)(cb =>
+      try {
+        cb(Left(10)); true
       } catch { case _: CallbackCalledMultipleTimesException => false }
     )
     run(10)(cb =>

--- a/core/shared/src/test/scala/monix/bio/TaskClockTimerAndContextShiftSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskClockTimerAndContextShiftSuite.scala
@@ -143,7 +143,7 @@ object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
   test("BIO.contextShift.evalOn(s2) fatal failure") { implicit s =>
     val s2 = TestScheduler()
     val dummy = DummyException("dummy")
-    val f = BIO.contextShift.evalOn(s2)(BIO.raiseFatalError(dummy)).runToFuture
+    val f = BIO.contextShift.evalOn(s2)(BIO.terminate(dummy)).runToFuture
 
     assertEquals(f.value, None)
     s.tick()
@@ -224,7 +224,7 @@ object TaskClockTimerAndContextShiftSuite extends BaseTestSuite {
   test("BIO.contextShift(s).evalOn(s2) fatal failure") { implicit s =>
     val s2 = TestScheduler()
     val dummy = DummyException("dummy")
-    val f = BIO.contextShift(s).evalOn(s2)(BIO.raiseFatalError(dummy)).runToFuture
+    val f = BIO.contextShift(s).evalOn(s2)(BIO.terminate(dummy)).runToFuture
 
     assertEquals(f.value, None)
     s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskConnectionSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskConnectionSuite.scala
@@ -330,7 +330,7 @@ object TaskConnectionSuite extends BaseTestSuite {
 
   test("throwing error in Task on cancel all") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = BIO.raiseFatalError(dummy)
+    val task = BIO.terminate(dummy)
 
     val c = TaskConnection[Throwable]()
     c.push(task)
@@ -341,9 +341,9 @@ object TaskConnectionSuite extends BaseTestSuite {
 
   test("throwing multiple errors in Tasks on cancel all") { implicit s =>
     val dummy1 = DummyException("dummy1")
-    val task1 = BIO.raiseFatalError(dummy1)
+    val task1 = BIO.terminate(dummy1)
     val dummy2 = DummyException("dummy2")
-    val task2 = BIO.raiseFatalError(dummy2)
+    val task2 = BIO.terminate(dummy2)
 
     val c = TaskConnection[Throwable]()
     c.push(task1)
@@ -368,7 +368,7 @@ object TaskConnectionSuite extends BaseTestSuite {
     c.cancel.runAsyncAndForget; s.tick()
 
     val dummy = DummyException("dummy")
-    val task = BIO.raiseFatalError(dummy)
+    val task = BIO.terminate(dummy)
     c.push(task); s.tick()
 
     assertEquals(s.state.lastReportedError, dummy)

--- a/core/shared/src/test/scala/monix/bio/TaskConversionsSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskConversionsSuite.scala
@@ -78,16 +78,16 @@ object TaskConversionsSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(dummy)))
   }
 
-  test("BIO.raiseFatalError(dummy).to[IO]") { implicit s =>
+  test("BIO.terminate(dummy).to[IO]") { implicit s =>
     val dummy = DummyException("dummy")
     intercept[DummyException] {
-      BIO.raiseFatalError(dummy).to[IO].unsafeRunSync()
+      BIO.terminate(dummy).to[IO].unsafeRunSync()
     }
   }
 
-  test("BIO.raiseFatalError(dummy).executeAsync.to[IO]") { implicit s =>
+  test("BIO.terminate(dummy).executeAsync.to[IO]") { implicit s =>
     val dummy = DummyException("dummy")
-    val io = BIO.raiseFatalError(dummy).executeAsync.to[IO]
+    val io = BIO.terminate(dummy).executeAsync.to[IO]
     val f = io.unsafeToFuture()
 
     assertEquals(f.value, None)
@@ -104,7 +104,7 @@ object TaskConversionsSuite extends BaseTestSuite {
   }
 
   test("BIO.toAsync converts tasks with typed errors") { implicit s =>
-    val ex = DummyException("Typed")
+    val ex = DummyException("TypedError")
     val io = BIO.raiseError(ex).executeAsync.toAsync[IO]
     val f = io.unsafeToFuture()
 
@@ -112,9 +112,9 @@ object TaskConversionsSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("BIO.toAsync converts tasks with fatal errors") { implicit s =>
+  test("BIO.toAsync converts tasks with terminal errors") { implicit s =>
     val ex = DummyException("Fatal")
-    val io = BIO.raiseFatalError(ex).executeAsync.toAsync[IO]
+    val io = BIO.terminate(ex).executeAsync.toAsync[IO]
     val f = io.unsafeToFuture()
 
     s.tick()
@@ -134,7 +134,7 @@ object TaskConversionsSuite extends BaseTestSuite {
   test("BIO.toConcurrent converts tasks with typed errors") { implicit s =>
     implicit val cs: ContextShift[IO] = IO.contextShift(s)
 
-    val ex = DummyException("Typed")
+    val ex = DummyException("TypedError")
     val io = BIO.raiseError(ex).executeAsync.toConcurrent[IO]
     val f = io.unsafeToFuture()
 
@@ -142,11 +142,11 @@ object TaskConversionsSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("BIO.toConcurrent converts tasks with fatal errors") { implicit s =>
+  test("BIO.toConcurrent converts tasks with terminal errors") { implicit s =>
     implicit val cs: ContextShift[IO] = IO.contextShift(s)
 
     val ex = DummyException("Fatal")
-    val io = BIO.raiseFatalError(ex).executeAsync.toConcurrent[IO]
+    val io = BIO.terminate(ex).executeAsync.toConcurrent[IO]
     val f = io.unsafeToFuture()
 
     s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskCreateSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskCreateSuite.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
 
 object TaskCreateSuite extends BaseTestSuite {
   test("can use Unit as return type") { implicit sc =>
-    val task = Task.create[Int]((_, cb) => cb.onSuccess(1))
+    val task = BIO.create[Long, Int]((_, cb) => cb.onSuccess(1))
     val f = task.runToFuture
 
     sc.tick()
@@ -34,7 +34,7 @@ object TaskCreateSuite extends BaseTestSuite {
   }
 
   test("can use Cancelable.empty as return type") { implicit sc =>
-    val task = Task.create[Int] { (_, cb) =>
+    val task = BIO.create[Long, Int] { (_, cb) =>
       cb.onSuccess(1); Cancelable.empty
     }
     val f = task.runToFuture
@@ -46,7 +46,7 @@ object TaskCreateSuite extends BaseTestSuite {
   test("returning Unit yields non-cancelable tasks") { implicit sc =>
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
 
-    val task = Task.create[Int] { (sc, cb) =>
+    val task = BIO.create[Long, Int] { (sc, cb) =>
       sc.scheduleOnce(1.second)(cb.onSuccess(1))
       ()
     }
@@ -61,7 +61,7 @@ object TaskCreateSuite extends BaseTestSuite {
   }
 
   test("can use Cancelable as return type") { implicit sc =>
-    val task = Task.create[Int] { (sc, cb) =>
+    val task = BIO.create[Long, Int] { (sc, cb) =>
       sc.scheduleOnce(1.second)(cb.onSuccess(1))
     }
 
@@ -74,7 +74,7 @@ object TaskCreateSuite extends BaseTestSuite {
   }
 
   test("returning Cancelable yields a cancelable task") { implicit sc =>
-    val task = Task.create[Int] { (sc, cb) =>
+    val task = BIO.create[Long, Int] { (sc, cb) =>
       sc.scheduleOnce(1.second)(cb.onSuccess(1))
     }
 
@@ -147,7 +147,7 @@ object TaskCreateSuite extends BaseTestSuite {
 
   test("throwing error when returning Unit") { implicit sc =>
     val dummy = DummyException("dummy")
-    val task = Task.create[Int] { (_, _) =>
+    val task = BIO.create[Long, Int] { (_, _) =>
       (throw dummy): Unit
     }
 
@@ -160,7 +160,7 @@ object TaskCreateSuite extends BaseTestSuite {
 
   test("throwing error when returning Cancelable") { implicit sc =>
     val dummy = DummyException("dummy")
-    val task = Task.create[Int] { (_, _) =>
+    val task = BIO.create[Long, Int] { (_, _) =>
       (throw dummy): Cancelable
     }
 

--- a/core/shared/src/test/scala/monix/bio/TaskDeferActionSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskDeferActionSuite.scala
@@ -80,19 +80,19 @@ object TaskDeferActionSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(10000))))
   }
 
-//  testAsync("deferAction(local.write) works") { _ =>
-//    import monix.execution.Scheduler.Implicits.global
-//    implicit val opts = BIO.defaultOptions.enableLocalContextPropagation
-//
-//    val task = for {
-//      l <- TaskLocal(10)
-//      _ <- Task.deferAction(_ => l.write(100))
-//      _ <- Task.shift
-//      v <- l.read
-//    } yield v
-//
-//    for (v <- task.runToFutureOpt) yield {
-//      assertEquals(v, 100)
-//    }
-//  }
+  testAsync("BIO.deferAction(local.write) works") { _ =>
+    import monix.execution.Scheduler.Implicits.global
+    implicit val opts = BIO.defaultOptions.enableLocalContextPropagation
+
+    val task = for {
+      l <- TaskLocal(10)
+      _ <- BIO.deferAction(_ => l.write(100))
+      _ <- BIO.shift
+      v <- l.read
+    } yield v
+
+    for (v <- task.runToFutureOpt) yield {
+      assertEquals(v, Right(100))
+    }
+  }
 }

--- a/core/shared/src/test/scala/monix/bio/TaskDoOnCancelSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskDoOnCancelSuite.scala
@@ -20,7 +20,7 @@ package monix.bio
 import monix.execution.exceptions.DummyException
 
 import scala.concurrent.duration._
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskDoOnCancelSuite extends BaseTestSuite {
   test("doOnCancel should normally mirror the source") { implicit s =>
@@ -28,7 +28,7 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .delayExecution(1.second)
       .doOnCancel(UIO.eval { effect1 += 1 })
@@ -47,8 +47,8 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
 
   test("doOnCancel should mirror failed sources") { implicit s =>
     var effect = 0
-    val dummy = new RuntimeException("dummy")
-    val f = Task
+    val dummy = "dummy"
+    val f = BIO
       .raiseError(dummy)
       .executeAsync
       .doOnCancel(UIO.eval { effect += 1 })
@@ -59,12 +59,26 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     assertEquals(effect, 0)
   }
 
+  test("doOnCancel should mirror terminated sources") { implicit s =>
+    var effect = 0
+    val dummy = new RuntimeException("dummy")
+    val f = BIO
+      .terminate(dummy)
+      .executeAsync
+      .doOnCancel(UIO.eval { effect += 1 })
+      .runToFuture
+
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+    assertEquals(effect, 0)
+  }
+
   test("doOnCancel should cancel delayResult #1") { implicit s =>
     var effect1 = 0
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .delayResult(1.second)
       .doOnCancel(UIO.eval { effect1 += 1 })
@@ -91,7 +105,7 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .delayResult(1.second)
       .doOnCancel(UIO.eval { effect1 += 1 })
@@ -118,7 +132,7 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .delayResult(1.second)
       .doOnCancel(UIO.eval { effect1 += 1 })
@@ -145,7 +159,7 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .doOnCancel(UIO.eval { effect1 += 1 })
       .delayExecution(1.second)
@@ -172,7 +186,7 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
     var effect2 = 0
     var effect3 = 0
 
-    val f = Task
+    val f = UIO
       .eval(1)
       .doOnCancel(UIO.eval { effect1 += 1 })
       .delayExecution(1.second)
@@ -197,12 +211,12 @@ object TaskDoOnCancelSuite extends BaseTestSuite {
   test("doOnCancel is stack safe in flatMap loops") { implicit sc =>
     val onCancel = UIO.evalAsync(throw DummyException("dummy"))
 
-    def loop(n: Int, acc: Long): Task[Long] =
-      Task.unit.doOnCancel(onCancel).flatMap { _ =>
+    def loop(n: Int, acc: Long): UIO[Long] =
+      UIO.unit.doOnCancel(onCancel).flatMap { _ =>
         if (n > 0)
           loop(n - 1, acc + 1)
         else
-          Task.now(acc)
+          UIO.now(acc)
       }
 
     val f = loop(10000, 0).runToFuture; sc.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskErrorSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskErrorSuite.scala
@@ -25,40 +25,54 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskErrorSuite extends BaseTestSuite {
-  test("Task.attempt should expose error") { implicit s =>
-    val dummy = DummyException("dummy")
-    val r = Task.raiseError[Int](dummy).attempt.runSyncStep
+  test("BIO.attempt should expose typed error") { implicit s =>
+    val dummy = "dummy"
+    val r = BIO.raiseError(dummy).attempt.runSyncStep
     assertEquals(r, Right(Left(dummy)))
   }
 
-  test("Task.attempt should work for successful values") { implicit s =>
-    val r = Task.now(10).attempt.runSyncStep
+  test("BIO.attempt should not expose unexpected error") { implicit s =>
+    val dummy = DummyException("dummy")
+    val f = BIO.terminate(dummy).attempt.runToFuture
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("BIO.attempt should work for successful values") { implicit s =>
+    val r = BIO.now(10).attempt.runSyncStep
     assertEquals(r, Right(Right(10)))
   }
 
-  test("Task.fail should expose error") { implicit s =>
-    val dummy = DummyException("dummy")
-    val r = Task.raiseError[Int](dummy).failed.runSyncStep
+  test("BIO.failed should expose typed error") { implicit s =>
+    val dummy = "dummy"
+    val r = BIO.raiseError(dummy).failed.runSyncStep
     assertEquals(r, Right(dummy))
   }
 
-  test("Task.fail should fail for successful values") { implicit s =>
-    intercept[NoSuchElementException] {
-      Task.now(10).failed.runSyncStep
+  test("BIO.failed should fail for unexpected error") { implicit s =>
+    val dummy = DummyException("dummy")
+
+    intercept[DummyException] {
+      BIO.terminate(dummy).failed.runSyncStep
     }
   }
 
-  test("Task#onErrorRecover should mirror source on success") { implicit s =>
-    val task = Task.evalAsync(1).onErrorRecover { case _: Throwable => 99 }
+  test("BIO.failed should fail for successful values") { implicit s =>
+    intercept[NoSuchElementException] {
+      BIO.now(10).failed.runSyncStep
+    }
+  }
+
+  test("BIO#onErrorRecover should mirror source on success") { implicit s =>
+    val task = (UIO.evalAsync(1): BIO[String, Int]).onErrorRecover { case _: String => 99 }
     val f = task.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task#onErrorRecover should recover") { implicit s =>
-    val ex = DummyException("dummy")
-    val task = Task[Int](if (1 == 1) throw ex else 1).onErrorRecover {
-      case _: DummyException => 99
+  test("BIO#onErrorRecover should recover typed error") { implicit s =>
+    val ex = "dummy"
+    val task = (BIO.raiseError(ex): BIO[String, Int]).onErrorRecover {
+      case "dummy" => 99
     }
 
     val f = task.runToFuture
@@ -66,18 +80,29 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(99))))
   }
 
-  test("Task#onErrorRecover should protect against user code") { implicit s =>
+  test("BIO#onErrorRecover should not recover unexpected error") { implicit s =>
+    val ex = DummyException("dummy")
+    val task = (BIO.terminate(ex): BIO[String, Int]).onErrorRecover {
+      case _ => 99
+    }
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO#onErrorRecover should protect against user code") { implicit s =>
     val ex1 = DummyException("one")
     val ex2 = DummyException("two")
 
-    val task = Task[Int](if (1 == 1) throw ex1 else 1).onErrorRecover { case _ => throw ex2 }
+    val task = BIO[Int](if (1 == 1) throw ex1 else 1).onErrorRecover { case _ => throw ex2 }
 
     val f = task.runToFuture; s.tick()
     assertEquals(f.value, Some(Failure(ex2)))
   }
 
-  test("Task#onErrorHandle should mirror source on success") { implicit s =>
-    val task = Task.evalAsync(1).onErrorHandle { _: Throwable =>
+  test("BIO#onErrorHandle should mirror source on success") { implicit s =>
+    val task = (UIO.evalAsync(1): BIO[String, Int]).onErrorHandle { _: String =>
       99
     }
     val f = task.runToFuture
@@ -85,10 +110,10 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task#onErrorHandle should recover") { implicit s =>
-    val ex = DummyException("dummy")
-    val task = Task[Int](if (1 == 1) throw ex else 1).onErrorHandle {
-      case _: DummyException => 99
+  test("BIO#onErrorHandle should recover typed error") { implicit s =>
+    val ex = "dummy"
+    val task = (BIO.raiseError(ex): BIO[String, Int]).onErrorHandle { _: String =>
+      99
     }
 
     val f = task.runToFuture
@@ -96,11 +121,22 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(99))))
   }
 
-  test("Task#onErrorHandle should protect against user code") { implicit s =>
-    val ex1 = DummyException("one")
+  test("BIO#onErrorHandle should not recover unexpected error") { implicit s =>
+    val ex = DummyException("dummy")
+    val task = BIO.evalTotal[Int](if (1 == 1) throw ex else 1).onErrorHandle { _ =>
+      99
+    }
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO#onErrorHandle should protect against user code") { implicit s =>
+    val ex1 = "one"
     val ex2 = DummyException("two")
 
-    val task = Task[Int](if (1 == 1) throw ex1 else 1).onErrorHandle { _ =>
+    val task = (BIO.raiseError(ex1): BIO[String, Int]).onErrorHandle { _ =>
       throw ex2
     }
 
@@ -108,33 +144,41 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex2)))
   }
 
-  test("Task.onErrorFallbackTo should mirror source onSuccess") { implicit s =>
-    val task = Task.evalAsync(1).onErrorFallbackTo(Task.evalAsync(2))
+  test("BIO.onErrorFallbackTo should mirror source onSuccess") { implicit s =>
+    val task = UIO.evalAsync(1).onErrorFallbackTo(UIO.evalAsync(2))
     val f = task.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task.onErrorFallbackTo should fallback to backup onError") { implicit s =>
-    val ex = DummyException("dummy")
-    val task = Task.evalAsync(throw ex).onErrorFallbackTo(Task.evalAsync(2))
+  test("BIO.onErrorFallbackTo should fallback to backup onError") { implicit s =>
+    val ex = "dummy"
+    val task = (BIO.raiseError(ex): BIO[String, Int]).onErrorFallbackTo(UIO.evalAsync(2))
     val f = task.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Right(2))))
   }
 
-  test("Task.onErrorFallbackTo should protect against user code") { implicit s =>
+  test("BIO.onErrorFallbackTo should not fallback to backup onTermination") { implicit s =>
     val ex = DummyException("dummy")
+    val task = (BIO.terminate(ex): BIO[String, Int]).onErrorFallbackTo(UIO.evalAsync(2))
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO.onErrorFallbackTo should protect against user code") { implicit s =>
+    val ex = "dummy"
     val err = DummyException("unexpected")
-    val task = Task.evalAsync(throw ex).onErrorFallbackTo(Task.defer(throw err))
+    val task = (BIO.raiseError(ex): BIO[String, Int]).executeAsync.onErrorFallbackTo(BIO.defer(throw err))
     val f = task.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Left(err))))
   }
 
-  test("Task.onErrorFallbackTo should be cancelable if the ExecutionModel allows it") { implicit s =>
-    def recursive(): Task[Int] = {
-      Task[Int](throw DummyException("dummy")).onErrorFallbackTo(Task.defer(recursive()))
+  test("BIO.onErrorFallbackTo should be cancelable if the ExecutionModel allows it") { implicit s =>
+    def recursive(): UIO[Int] = {
+      BIO.raiseError("dummy").onErrorFallbackTo(BIO.deferTotal(recursive()))
     }
 
     val task = recursive().executeWithOptions(_.enableAutoCancelableRunLoops)
@@ -146,38 +190,38 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.onErrorRestart should mirror the source onSuccess") { implicit s =>
+  test("BIO.onErrorRestart should mirror the source onSuccess") { implicit s =>
     var tries = 0
-    val task = Task.eval { tries += 1; 1 }.onErrorRestart(10)
+    val task = UIO.eval { tries += 1; 1 }.onErrorRestart(10)
     val f = task.runToFuture
 
     assertEquals(f.value, Some(Success(Right(1))))
     assertEquals(tries, 1)
   }
 
-  test("Task.onErrorRestart should retry onError") { implicit s =>
-    val ex = DummyException("dummy")
+  test("BIO.onErrorRestart should retry onError") { implicit s =>
+    val ex = "dummy"
     var tries = 0
-    val task = Task.eval { tries += 1; if (tries < 5) throw ex else 1 }.onErrorRestart(10)
+    val task = BIO.deferTotal { tries += 1; if (tries < 5) BIO.raiseError(ex) else BIO.now(1) }.onErrorRestart(10)
     val f = task.runToFuture
 
     assertEquals(f.value, Some(Success(Right(1))))
     assertEquals(tries, 5)
   }
 
-  test("Task.onErrorRestart should emit onError after max retries") { implicit s =>
+  test("BIO.onErrorRestart should emit onError after max retries") { implicit s =>
     val ex = DummyException("dummy")
     var tries = 0
-    val task = Task.eval { tries += 1; throw ex }.onErrorRestart(10)
+    val task = BIO.eval { tries += 1; throw ex }.onErrorRestart(10)
     val f = task.runToFuture
 
     assertEquals(f.value, Some(Success(Left(ex))))
     assertEquals(tries, 11)
   }
 
-  test("Task.onErrorRestart should be cancelable if ExecutionModel permits") { implicit s =>
+  test("BIO.onErrorRestart should be cancelable if ExecutionModel permits") { implicit s =>
     val batchSize = (s.executionModel.recommendedBatchSize * 2).toLong
-    val task = Task[Int](throw DummyException("dummy"))
+    val task = BIO[Int](throw DummyException("dummy"))
       .onErrorRestart(batchSize)
 
     val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runToFuture
@@ -188,29 +232,29 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.onErrorRestart should not restart on fatal error") { implicit s =>
+  test("BIO.onErrorRestart should not restart on terminate error") { implicit s =>
     var tries = 0
     val ex = DummyException("dummy")
-    val task = Task.eval { tries += 1; throw ex }.hideErrors.onErrorRestart(5)
+    val task = BIO.eval { tries += 1; throw ex }.hideErrors.onErrorRestart(5)
     val f = task.runToFuture
 
     assertEquals(f.value, Some(Failure(ex)))
     assertEquals(tries, 1)
   }
 
-  test("Task.onErrorRestartIf should mirror the source onSuccess") { implicit s =>
+  test("BIO.onErrorRestartIf should mirror the source onSuccess") { implicit s =>
     var tries = 0
-    val task = Task.eval { tries += 1; 1 }.onErrorRestartIf(_ => tries < 10)
+    val task = BIO.eval { tries += 1; 1 }.onErrorRestartIf(_ => tries < 10)
     val f = task.runToFuture
 
     assertEquals(f.value, Some(Success(Right(1))))
     assertEquals(tries, 1)
   }
 
-  test("Task.onErrorRestartIf should retry onError") { implicit s =>
+  test("BIO.onErrorRestartIf should retry onError") { implicit s =>
     val ex = DummyException("dummy")
     var tries = 0
-    val task = Task.eval { tries += 1; if (tries < 5) throw ex else 1 }
+    val task = BIO.eval { tries += 1; if (tries < 5) throw ex else 1 }
       .onErrorRestartIf(_ => tries <= 10)
 
     val f = task.runToFuture
@@ -218,10 +262,10 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(tries, 5)
   }
 
-  test("Task.onErrorRestartIf should emit onError") { implicit s =>
+  test("BIO.onErrorRestartIf should emit onError") { implicit s =>
     val ex = DummyException("dummy")
     var tries = 0
-    val task = Task.eval { tries += 1; throw ex }
+    val task = BIO.eval { tries += 1; throw ex }
       .onErrorRestartIf(_ => tries <= 10)
 
     val f = task.runToFuture
@@ -229,8 +273,8 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(tries, 11)
   }
 
-  test("Task.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
-    val task = Task[Int](throw DummyException("dummy")).onErrorRestartIf(_ => true)
+  test("BIO.onErrorRestartIf should be cancelable if ExecutionModel permits") { implicit s =>
+    val task = BIO[Int](throw DummyException("dummy")).onErrorRestartIf(_ => true)
     val f = task.executeWithOptions(_.enableAutoCancelableRunLoops).runToFuture
     assertEquals(f.value, None)
 
@@ -239,17 +283,17 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.onErrorRestartIf should not restart on fatal error") { implicit s =>
+  test("BIO.onErrorRestartIf should not restart on terminate error") { implicit s =>
     var tries = 0
     val ex = DummyException("dummy")
-    val task: Task[Int] = Task.eval { tries += 1; throw ex }.hideErrors
+    val task: UIO[Int] = BIO.eval { tries += 1; throw ex }.hideErrors
     val f = task.onErrorRestartIf(_ => tries < 5).runToFuture
 
     assertEquals(f.value, Some(Failure(ex)))
     assertEquals(tries, 1)
   }
 
-  test("Task.onErrorRestartIf should restart on typed error") { implicit s =>
+  test("BIO.onErrorRestartIf should restart on typed error") { implicit s =>
     var tries = 0
     val task = BIO.unit.flatMap { _ =>
       tries += 1; if (tries < 5) BIO.raiseError("error") else BIO.pure(1)
@@ -259,17 +303,17 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(tries, 5)
   }
 
-  test("Task#onErrorRecoverWith should mirror source on success") { implicit s =>
-    val task = Task.evalAsync(1).onErrorRecoverWith { case _: Throwable => Task.evalAsync(99) }
+  test("BIO#onErrorRecoverWith should mirror source on success") { implicit s =>
+    val task = (UIO.evalAsync(1): BIO[Int, Int]).onErrorRecoverWith { case _: Int => UIO.evalAsync(99) }
     val f = task.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task#onErrorRecoverWith should recover") { implicit s =>
+  test("BIO#onErrorRecoverWith should recover") { implicit s =>
     val ex = DummyException("dummy")
-    val task = Task[Int](throw ex).onErrorRecoverWith {
-      case _: DummyException => Task.evalAsync(99)
+    val task = BIO[Int](throw ex).onErrorRecoverWith {
+      case _: DummyException => BIO.evalAsync(99)
     }
 
     val f = task.runToFuture
@@ -277,19 +321,19 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(99))))
   }
 
-  test("Task#onErrorRecoverWith should protect against user code") { implicit s =>
+  test("BIO#onErrorRecoverWith should protect against user code") { implicit s =>
     val ex1 = DummyException("one")
     val ex2 = DummyException("two")
 
-    val task = Task[Int](throw ex1).onErrorRecoverWith { case _ => throw ex2 }
+    val task = BIO[Int](throw ex1).onErrorRecoverWith { case _ => throw ex2 }
 
     val f = task.runToFuture; s.tick()
     assertEquals(f.value, Some(Failure(ex2)))
   }
 
-  test("Task#onErrorRecoverWith has a cancelable fallback") { implicit s =>
-    val task = Task[Int](throw DummyException("dummy")).onErrorRecoverWith {
-      case _: DummyException => Task.evalAsync(99).delayExecution(1.second)
+  test("BIO#onErrorRecoverWith has a cancelable fallback") { implicit s =>
+    val task = BIO[Int](throw DummyException("dummy")).onErrorRecoverWith {
+      case _: DummyException => BIO.evalAsync(99).delayExecution(1.second)
     }
 
     val f = task.runToFuture
@@ -301,49 +345,47 @@ object TaskErrorSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task#onErrorRecover should emit error if not matches") { implicit s =>
+  test("BIO#onErrorRecover should emit error if not matches") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task[Int](throw dummy).onErrorRecover { case _: TimeoutException => 10 }
+    val task = BIO[Int](throw dummy).onErrorRecover { case _: TimeoutException => 10 }
     val f = task.runToFuture; s.tick()
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("Task#onErrorRecoverWith should emit error if not matches") { implicit s =>
+  test("BIO#onErrorRecoverWith should emit error if not matches") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = Task[Int](throw dummy).onErrorRecoverWith { case _: TimeoutException => Task.now(10) }
+    val task = BIO[Int](throw dummy).onErrorRecoverWith { case _: TimeoutException => Task.now(10) }
     val f = task.runToFuture; s.tick()
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  // TODO: add tests for variants catching fatal errors instead
-//  test("Task.eval.flatMap.onErrorRecoverWith should work") { implicit s =>
-//    val dummy = DummyException("dummy")
-//    val task = Task.eval(1).flatMap(_ => throw dummy).onErrorRecoverWith { case `dummy` => Task.now(10) }
-//
-//    val f = task.runToFuture
-//    assertEquals(f.value, Some(Success(10)))
-//  }
-//
-//  test("Task.flatMap.onErrorRecoverWith should work") { implicit s =>
-//    val dummy = DummyException("dummy")
-//    val task = Task.evalAsync(1).flatMap(_ => throw dummy).onErrorRecoverWith { case `dummy` => Task.now(10) }
-//
-//    val f = task.runToFuture; s.tick()
-//    assertEquals(f.value, Some(Success(10)))
-//  }
-//
+  test("BIO.eval.flatMap.redeemCauseWith should work") { implicit s =>
+    val dummy = DummyException("dummy")
+    val task = UIO.eval(1).flatMap(_ => throw dummy).redeemCauseWith(_ => BIO.now(10), BIO.now)
 
-  test("Task.now.onErrorRecoverWith should be stack safe") { implicit s =>
-    val ex = DummyException("dummy1")
+    val f = task.runToFuture
+    assertEquals(f.value, Some(Success(Right(10))))
+  }
+
+  test("BIO.evalAsync.flatMap.redeemCauseWith should work") { implicit s =>
+    val dummy = DummyException("dummy")
+    val task = UIO.evalAsync(1).flatMap(_ => throw dummy).redeemCauseWith(_ => BIO.now(10), BIO.now)
+
+    val f = task.runToFuture; s.tick()
+    assertEquals(f.value, Some(Success(Right(10))))
+  }
+
+  test("BIO.now.onErrorRecoverWith should be stack safe") { implicit s =>
+    val ex = 1111
     val count = if (Platform.isJVM) 50000 else 5000
 
-    def loop(task: Task[Int], n: Int): Task[Int] =
+    def loop(task: BIO[Int, Int], n: Int): BIO[Int, Int] =
       task.onErrorRecoverWith {
-        case `ex` if n <= 0 => Task.now(count)
+        case `ex` if n <= 0 => BIO.now(count)
         case `ex` => loop(task, n - 1)
       }
 
-    val task = loop(Task.raiseError(ex), count)
+    val task = loop(BIO.raiseError(ex), count)
     val result = task.runToFuture
 
     s.tick()
@@ -351,22 +393,22 @@ object TaskErrorSuite extends BaseTestSuite {
   }
 
   test("onErrorRecoverWith should be stack safe for loop with executeAsync boundaries") { implicit s =>
-    val ex = DummyException("dummy1")
+    val ex = 2222
     val count = if (Platform.isJVM) 50000 else 5000
 
-    def loop(task: Task[Int], n: Int): Task[Int] =
+    def loop(task: BIO[Int, Int], n: Int): BIO[Int, Int] =
       task.onErrorRecoverWith {
-        case `ex` if n <= 0 => Task.evalAsync(count)
+        case `ex` if n <= 0 => UIO.evalAsync(count)
         case `ex` => loop(task, n - 1).executeAsync
       }
 
-    val task = loop(Task.raiseError(ex), count)
+    val task = loop(BIO.raiseError(ex), count)
     val result = task.runToFuture
 
     s.tick()
     assertEquals(result.value, Some(Success(Right(count))))
   }
-//
+
 //  test("Task.onErrorRestartLoop works for success") { implicit s =>
 //    val dummy = DummyException("dummy")
 //    var tries = 0

--- a/core/shared/src/test/scala/monix/bio/TaskEvalAlwaysSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskEvalAlwaysSuite.scala
@@ -24,11 +24,11 @@ import monix.execution.exceptions.DummyException
 import scala.util.{Failure, Success}
 
 object TaskEvalAlwaysSuite extends BaseTestSuite {
-  test("Task.eval should work synchronously") { implicit s =>
+  test("BIO.eval should work synchronously") { implicit s =>
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.eval(trigger())
+    val task = BIO.eval(trigger())
     assert(!wasTriggered, "!wasTriggered")
 
     val f = task.runToFuture
@@ -36,9 +36,9 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right("result"))))
   }
 
-  test("Task.eval should protect against user code errors") { implicit s =>
+  test("BIO.eval should protect against user code errors") { implicit s =>
     val ex = DummyException("dummy")
-    val f = Task.eval[Int](if (1 == 1) throw ex else 1).runToFuture
+    val f = BIO.eval[Int](if (1 == 1) throw ex else 1).runToFuture
 
     assertEquals(f.value, Some(Success(Left(ex))))
     assertEquals(s.state.lastReportedError, null)
@@ -60,24 +60,24 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
 //    }
 //  }
 
-  test("Task.eval.flatMap should be equivalent with Task.eval") { implicit s =>
+  test("BIO.eval.flatMap should be equivalent with BIO.eval") { implicit s =>
     val ex = DummyException("dummy")
-    val t = Task.eval[Int](if (1 == 1) throw ex else 1).flatMap(Task.now)
-    check(t <-> Task.raiseError(ex))
+    val t = BIO.eval[Int](if (1 == 1) throw ex else 1).flatMap(BIO.now)
+    check(t <-> BIO.raiseError(ex))
   }
 
-  test("Task.eval.flatMap should protect against user code") { implicit s =>
+  test("BIO.eval.flatMap should protect against user code") { implicit s =>
     val ex = DummyException("dummy")
-    val t = Task.eval(1).flatMap[Throwable, Int](_ => throw ex)
-    check(t <-> Task.raiseFatalError(ex))
+    val t = BIO.eval(1).flatMap[Throwable, Int](_ => throw ex)
+    check(t <-> BIO.terminate(ex))
   }
 
-  test("Task.eval.flatMap should be tail recursive") { implicit s =>
-    def loop(n: Int, idx: Int): Task[Int] =
-      Task.eval(idx).flatMap { a =>
+  test("BIO.eval.flatMap should be tail recursive") { implicit s =>
+    def loop(n: Int, idx: Int): BIO[Throwable, Int] =
+      BIO.eval(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1)
         else
-          Task.eval(idx)
+          BIO.eval(idx)
       }
 
     val iterations = s.executionModel.recommendedBatchSize * 20
@@ -86,41 +86,41 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(iterations * 2))))
   }
 
-  test("Task.eval should not be cancelable") { implicit s =>
-    val t = Task.eval(10)
+  test("BIO.eval should not be cancelable") { implicit s =>
+    val t = BIO.eval(10)
     val f = t.runToFuture
     f.cancel()
     s.tick()
     assertEquals(f.value, Some(Success(Right(10))))
   }
 
-  test("Task.eval.coeval") { implicit s =>
-    val result = Task.eval(100).runSyncStep
+  test("BIO.eval.coeval") { implicit s =>
+    val result = BIO.eval(100).runSyncStep
     assertEquals(result, Right(100))
   }
 
-  test("Task.eval.flatMap should protect against user code errors") { implicit s =>
+  test("BIO.eval.flatMap should protect against user code errors") { implicit s =>
     val ex = DummyException("dummy")
-    val task: Task[Int] = Task.eval(1).flatMap(_ => throw ex)
-    assertEquals(task.redeemFatal(ex => Left(ex), v => Right(v)).runSyncStep, Right(Left(ex)))
+    val task: Task[Int] = BIO.eval(1).flatMap(_ => throw ex)
+    assertEquals(task.redeemCause(ex => Left(ex.flatten), v => Right(v)).runSyncStep, Right(Left(ex)))
   }
 
-  test("Task.delay is an alias for Task.eval") { implicit s =>
+  test("BIO.delay is an alias for BIO.eval") { implicit s =>
     var effect = 0
-    val ts = Task.delay { effect += 1; effect }
+    val ts = BIO.delay { effect += 1; effect }
 
     assertEquals(ts.runToFuture.value, Some(Success(Right(1))))
     assertEquals(ts.runToFuture.value, Some(Success(Right(2))))
     assertEquals(ts.runToFuture.value, Some(Success(Right(3))))
 
     val dummy = new DummyException("dummy")
-    val te = Task.delay { throw dummy }
+    val te = BIO.delay { throw dummy }
     assertEquals(te.runToFuture.value, Some(Success(Left(dummy))))
   }
 
   test("BIO.evalTotal should protect against unexpected errors") { implicit s =>
     val ex = DummyException("dummy")
-    val f = UIO.eval[Int](throw ex).redeemFatal(_ => 10, identity).runToFuture
+    val f = UIO.eval[Int](throw ex).redeemCause(_ => 10, identity).runToFuture
     val g = UIO.eval[Int](throw ex).onErrorHandle(_ => 10).runToFuture
 
     assertEquals(f.value, Some(Success(Right(10))))

--- a/core/shared/src/test/scala/monix/bio/TaskEvalAlwaysSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskEvalAlwaysSuite.scala
@@ -102,7 +102,7 @@ object TaskEvalAlwaysSuite extends BaseTestSuite {
   test("BIO.eval.flatMap should protect against user code errors") { implicit s =>
     val ex = DummyException("dummy")
     val task: Task[Int] = BIO.eval(1).flatMap(_ => throw ex)
-    assertEquals(task.redeemCause(ex => Left(ex.flatten), v => Right(v)).runSyncStep, Right(Left(ex)))
+    assertEquals(task.redeemCause(ex => Left(ex.toThrowable), v => Right(v)).runSyncStep, Right(Left(ex)))
   }
 
   test("BIO.delay is an alias for BIO.eval") { implicit s =>

--- a/core/shared/src/test/scala/monix/bio/TaskEvalAsyncSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskEvalAsyncSuite.scala
@@ -84,7 +84,7 @@ object TaskEvalAsyncSuite extends BaseTestSuite {
   test("Task.evalAsync.flatMap should protect against user code") { implicit s =>
     val ex = DummyException("dummy")
     val t = Task.evalAsync(1).flatMap[Throwable, Int](_ => throw ex)
-    check(t <-> Task.raiseFatalError(ex))
+    check(t <-> Task.terminate(ex))
   }
 
   test("Task.evalAsync should be tail recursive") { implicit s =>

--- a/core/shared/src/test/scala/monix/bio/TaskEvalAsyncSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskEvalAsyncSuite.scala
@@ -21,14 +21,14 @@ import cats.laws._
 import cats.laws.discipline._
 import monix.execution.exceptions.DummyException
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskEvalAsyncSuite extends BaseTestSuite {
-  test("Task.evalAsync should work, on different thread") { implicit s =>
+  test("BIO.evalAsync should work, on different thread") { implicit s =>
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.evalAsync(trigger())
+    val task = UIO.evalAsync(trigger())
     assert(!wasTriggered, "!wasTriggered")
 
     val f = task.runToFuture
@@ -40,25 +40,34 @@ object TaskEvalAsyncSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right("result"))))
   }
 
-  test("Task.evalAsync should protect against user code errors") { implicit s =>
+  test("BIO.evalAsync should protect against user code errors") { implicit s =>
     val ex = DummyException("dummy")
-    val f = Task[Int](if (1 == 1) throw ex else 1).runToFuture
+    val f = BIO.evalAsync[Int](if (1 == 1) throw ex else 1).runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Left(ex))))
     assertEquals(s.state.lastReportedError, null)
   }
 
-  test("Task.evalAsync is equivalent with Task.eval") { implicit s =>
+  test("UIO.evalAsync should protect against user code errors") { implicit s =>
+    val ex = DummyException("dummy")
+    val f = UIO.evalAsync[Int](if (1 == 1) throw ex else 1).runToFuture
+
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+    assertEquals(s.state.lastReportedError, null)
+  }
+
+  test("BIO.evalAsync is equivalent with BIO.eval") { implicit s =>
     check1 { a: Int =>
       val t1 = {
         var effect = 100
-        Task.evalAsync { effect += 100; effect + a }
+        BIO.evalAsync { effect += 100; effect + a }
       }
 
       val t2 = {
         var effect = 100
-        Task.eval { effect += 100; effect + a }
+        BIO.eval { effect += 100; effect + a }
       }
 
       List(t1 <-> t2, t2 <-> t1)
@@ -81,18 +90,18 @@ object TaskEvalAsyncSuite extends BaseTestSuite {
 //    }
 //  }
 
-  test("Task.evalAsync.flatMap should protect against user code") { implicit s =>
+  test("BIO.evalAsync.flatMap should protect against user code") { implicit s =>
     val ex = DummyException("dummy")
-    val t = Task.evalAsync(1).flatMap[Throwable, Int](_ => throw ex)
-    check(t <-> Task.terminate(ex))
+    val t = BIO.evalAsync(1).flatMap[Throwable, Int](_ => throw ex)
+    check(t <-> BIO.terminate(ex))
   }
 
-  test("Task.evalAsync should be tail recursive") { implicit s =>
+  test("BIO.evalAsync should be tail recursive") { implicit s =>
     def loop(n: Int, idx: Int): Task[Int] =
-      Task.evalAsync(idx).flatMap { idx =>
+      BIO.evalAsync(idx).flatMap { idx =>
         if (idx < n) loop(n, idx + 1).map(_ + 1)
         else
-          Task.evalAsync(idx)
+          BIO.evalAsync(idx)
       }
 
     val iterations = s.executionModel.recommendedBatchSize * 20
@@ -102,15 +111,15 @@ object TaskEvalAsyncSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(iterations * 2))))
   }
 
-  test("Task.evalAsync.flatten is equivalent with flatMap") { implicit s =>
+  test("BIO.evalAsync.flatten is equivalent with flatMap") { implicit s =>
     check1 { a: Int =>
-      val t = Task.evalAsync(Task.eval(a))
+      val t = BIO.evalAsync(BIO.eval(a))
       t.flatMap(identity) <-> t.flatten
     }
   }
 
-  test("Task.evalAsync.coeval") { implicit s =>
-    val f = Task.evalAsync(100).runToFuture
+  test("BIO.evalAsync.coeval") { implicit s =>
+    val f = BIO.evalAsync(100).runToFuture
     f.value match {
       case None =>
         s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskExecuteAsyncSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskExecuteAsyncSuite.scala
@@ -23,8 +23,8 @@ import monix.execution.schedulers.TestScheduler
 import scala.util.Success
 
 object TaskExecuteAsyncSuite extends BaseTestSuite {
-  test("Task.now.executeAsync should execute async") { implicit s =>
-    val t = Task.now(10).executeAsync
+  test("BIO.now.executeAsync should execute async") { implicit s =>
+    val t = BIO.now(10).executeAsync
     val f = t.runToFuture
 
     assertEquals(f.value, None)
@@ -32,9 +32,9 @@ object TaskExecuteAsyncSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(10))))
   }
 
-  test("Task.now.executeOn should execute async if forceAsync = true") { implicit s =>
+  test("BIO.now.executeOn should execute async if forceAsync = true") { implicit s =>
     val s2 = TestScheduler()
-    val t = Task.now(10).executeOn(s2)
+    val t = BIO.now(10).executeOn(s2)
     val f = t.runToFuture
 
     assertEquals(f.value, None)
@@ -46,18 +46,18 @@ object TaskExecuteAsyncSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(10))))
   }
 
-  test("Task.now.executeOn should not execute async if forceAsync = false") { implicit s =>
+  test("BIO.now.executeOn should not execute async if forceAsync = false") { implicit s =>
     val s2 = TestScheduler()
-    val t = Task.now(10).executeOn(s2, forceAsync = false)
+    val t = BIO.now(10).executeOn(s2, forceAsync = false)
     val f = t.runToFuture
 
     assertEquals(f.value, Some(Success(Right(10))))
   }
 
-  test("Task.create.executeOn should execute async") { implicit s =>
+  test("BIO.create.executeOn should execute async") { implicit s =>
     val s2 = TestScheduler()
-    val source = Task.cancelable0[Int] { (_, cb) =>
-      cb.onSuccess(10); Task.unit
+    val source = BIO.cancelable0[Int, Int] { (_, cb) =>
+      cb.onSuccess(10); BIO.unit
     }
     val t = source.executeOn(s2)
     val f = t.runToFuture
@@ -73,7 +73,7 @@ object TaskExecuteAsyncSuite extends BaseTestSuite {
 
   test("executeAsync should be stack safe, test 1") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 5000
-    var task = Task.eval(1)
+    var task = BIO.eval(1)
     for (_ <- 0 until count) task = task.executeAsync
 
     val result = task.runToFuture
@@ -81,9 +81,9 @@ object TaskExecuteAsyncSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(Right(1))))
   }
 
-  test("Task.executeOn should be stack safe, test 2") { implicit s =>
+  test("BIO.executeOn should be stack safe, test 2") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 5000
-    var task = Task.eval(1)
+    var task = BIO.eval(1)
     for (_ <- 0 until count) task = task.executeOn(s)
 
     val result = task.runToFuture
@@ -94,9 +94,9 @@ object TaskExecuteAsyncSuite extends BaseTestSuite {
   test("executeAsync should be stack safe, test 3") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 5000
 
-    def loop(n: Int): Task[Int] =
-      if (n <= 0) Task.now(0).executeAsync
-      else Task.now(n).executeAsync.flatMap(_ => loop(n - 1))
+    def loop(n: Int): UIO[Int] =
+      if (n <= 0) BIO.now(0).executeAsync
+      else BIO.now(n).executeAsync.flatMap(_ => loop(n - 1))
 
     val result = loop(count).runToFuture
     s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskExecuteWithModelSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskExecuteWithModelSuite.scala
@@ -24,8 +24,8 @@ import scala.util.Success
 
 object TaskExecuteWithModelSuite extends BaseTestSuite {
 
-  def readModel: Task[ExecutionModel] =
-    Task.deferAction(s => Task.now(s.executionModel))
+  def readModel: UIO[ExecutionModel] =
+    BIO.deferAction(s => BIO.now(s.executionModel))
 
   test("executeWithModel works") { implicit sc =>
     assertEquals(sc.executionModel, ExecutionModel.Default)
@@ -71,12 +71,12 @@ object TaskExecuteWithModelSuite extends BaseTestSuite {
   }
 
   test("executeWithModel is stack safe in flatMap loops") { implicit sc =>
-    def loop(n: Int, acc: Long): Task[Long] =
-      Task.unit.executeWithModel(SynchronousExecution).flatMap { _ =>
+    def loop(n: Int, acc: Long): UIO[Long] =
+      BIO.unit.executeWithModel(SynchronousExecution).flatMap { _ =>
         if (n > 0)
           loop(n - 1, acc + 1)
         else
-          Task.now(acc)
+          BIO.now(acc)
       }
 
     val f = loop(10000, 0).runToFuture; sc.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskExecuteWithOptionsSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskExecuteWithOptionsSuite.scala
@@ -23,9 +23,9 @@ import scala.util.Success
 
 object TaskExecuteWithOptionsSuite extends BaseTestSuite {
   test("executeWithOptions works") { implicit s =>
-    val task = Task
+    val task = BIO
       .eval(1)
-      .flatMap(_ => Task.eval(2))
+      .flatMap(_ => BIO.eval(2))
       .flatMap(_ => BIO.readOptions)
       .executeWithOptions(_.enableLocalContextPropagation)
       .flatMap(opt1 => BIO.readOptions.map(opt2 => (opt1, opt2)))
@@ -46,7 +46,7 @@ object TaskExecuteWithOptionsSuite extends BaseTestSuite {
     val task = for {
       l <- TaskLocal(10)
       _ <- l.write(100).executeWithOptions(_.enableAutoCancelableRunLoops)
-      _ <- Task.shift
+      _ <- BIO.shift
       v <- l.read
     } yield v
 
@@ -56,14 +56,12 @@ object TaskExecuteWithOptionsSuite extends BaseTestSuite {
   }
 
   test("executeWithOptions is stack safe in flatMap loops") { implicit sc =>
-    val sc2 = TestScheduler()
-
-    def loop(n: Int, acc: Long): Task[Long] =
-      Task.unit.executeWithOptions(_.enableAutoCancelableRunLoops).flatMap { _ =>
+    def loop(n: Int, acc: Long): UIO[Long] =
+      BIO.unit.executeWithOptions(_.enableAutoCancelableRunLoops).flatMap { _ =>
         if (n > 0)
           loop(n - 1, acc + 1)
         else
-          Task.now(acc)
+          BIO.now(acc)
       }
 
     val f = loop(10000, 0).runToFuture; sc.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskExecutionModelSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskExecutionModelSuite.scala
@@ -22,23 +22,23 @@ import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import scala.util.Success
 
 object TaskExecutionModelSuite extends BaseTestSuite {
-  test("Task.now.executeWithModel(AlwaysAsyncExecution) should work") { implicit s =>
-    val task = Task.now(1).executeWithModel(AlwaysAsyncExecution)
+  test("BIO.now.executeWithModel(AlwaysAsyncExecution) should work") { implicit s =>
+    val task = BIO.now(1).executeWithModel(AlwaysAsyncExecution)
     val f = task.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task.now.runAsync (CancelableFuture) should not be async with AlwaysAsyncExecution") { s =>
+  test("BIO.now.runAsync (CancelableFuture) should not be async with AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
-    val task = Task.now(1)
+    val task = BIO.now(1)
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task.eval.executeWithModel(AlwaysAsyncExecution) should work") { implicit s =>
-    val task = Task.eval(1).executeWithModel(AlwaysAsyncExecution)
+  test("BIO.eval.executeWithModel(AlwaysAsyncExecution) should work") { implicit s =>
+    val task = BIO.eval(1).executeWithModel(AlwaysAsyncExecution)
     val f = task.runToFuture
 
     assertEquals(f.value, None)
@@ -46,9 +46,9 @@ object TaskExecutionModelSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task.eval should be async with AlwaysAsyncExecution") { s =>
+  test("BIO.eval should be async with AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
-    val task = Task.eval(1)
+    val task = BIO.eval(1)
     val f = task.runToFuture
 
     assertEquals(f.value, None)
@@ -56,13 +56,13 @@ object TaskExecutionModelSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
-  test("Task.now.flatMap loops should work with AlwaysAsyncExecution") { s =>
+  test("BIO.now.flatMap loops should work with AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
-    def loop(count: Int): Task[Int] =
-      Task.now(count).flatMap { nr =>
+    def loop(count: Int): UIO[Int] =
+      BIO.now(count).flatMap { nr =>
         if (nr > 0) loop(count - 1)
-        else Task.now(nr)
+        else BIO.now(nr)
       }
 
     val task = loop(100)
@@ -73,13 +73,13 @@ object TaskExecutionModelSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(0))))
   }
 
-  test("Task.eval.flatMap loops should work with AlwaysAsyncExecution") { s =>
+  test("BIO.eval.flatMap loops should work with AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
     def loop(count: Int): Task[Int] =
-      Task.eval(count).flatMap { nr =>
+      BIO.eval(count).flatMap { nr =>
         if (nr > 0) loop(count - 1)
-        else Task.eval(nr)
+        else BIO.eval(nr)
       }
 
     val task = loop(100)
@@ -90,13 +90,13 @@ object TaskExecutionModelSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(0))))
   }
 
-  test("Task.flatMap loops should work with AlwaysAsyncExecution") { s =>
+  test("BIO.flatMap loops should work with AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
     def loop(count: Int): Task[Int] =
-      Task.evalAsync(count).flatMap { nr =>
+      BIO.evalAsync(count).flatMap { nr =>
         if (nr > 0) loop(count - 1)
-        else Task.evalAsync(nr)
+        else BIO.evalAsync(nr)
       }
 
     val task = loop(100)

--- a/core/shared/src/test/scala/monix/bio/TaskFlatMapSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskFlatMapSuite.scala
@@ -21,7 +21,7 @@ import cats.laws._
 import cats.laws.discipline._
 import monix.bio.internal.BiCallback
 import monix.execution.atomic.{Atomic, AtomicInt}
-import monix.execution.exceptions.DummyException
+import monix.execution.exceptions.{DummyException, UncaughtErrorException}
 import monix.execution.internal.Platform
 
 import scala.util.{Failure, Success, Try}
@@ -31,7 +31,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
     val maxCount = Platform.recommendedBatchSize * 4
 
-    def loop(count: AtomicInt): Task[Unit] =
+    def loop(count: AtomicInt): UIO[Unit] =
       if (count.incrementAndGet() >= maxCount) BIO.unit
       else
         BIO.unit.flatMap(_ => loop(count))
@@ -48,7 +48,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
     val maxCount = Platform.recommendedBatchSize * 4
     val expected = Platform.recommendedBatchSize
 
-    def loop(count: AtomicInt): Task[Unit] =
+    def loop(count: AtomicInt): UIO[Unit] =
       if (count.getAndIncrement() >= maxCount) BIO.unit
       else
         BIO.unit.flatMap(_ => loop(count))
@@ -72,7 +72,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
     val maxCount = Platform.recommendedBatchSize * 4
     val expected = Platform.recommendedBatchSize
 
-    def loop(count: AtomicInt): Task[Unit] =
+    def loop(count: AtomicInt): BIO[Int, Unit] =
       if (count.getAndIncrement() >= maxCount) BIO.unit
       else
         BIO.unit.flatMap(_ => loop(count))
@@ -83,15 +83,15 @@ object TaskFlatMapSuite extends BaseTestSuite {
     val c = loop(atomic)
       .executeWithOptions(_.enableAutoCancelableRunLoops)
       .runAsync(
-        new BiCallback[Cause[Throwable], Unit] {
-          override def onFatalError(e: Throwable): Unit =
+        new BiCallback[Cause[Int], Unit] {
+          override def onTermination(e: Throwable): Unit =
             result = Some(Failure(e))
 
           override def onSuccess(value: Unit): Unit =
             result = Some(Success(value))
 
-          override def onError(e: Cause[Throwable]): Unit =
-            result = Some(Failure(e.flatten))
+          override def onError(e: Cause[Int]): Unit =
+            result = Some(Failure(e.fold(identity, UncaughtErrorException.wrap)))
         }
       )
 
@@ -104,38 +104,38 @@ object TaskFlatMapSuite extends BaseTestSuite {
   }
 
   test("redeemWith derives flatMap") { implicit s =>
-    check2 { (fa: Task[Int], f: Int => Task[Int]) =>
+    check2 { (fa: BIO[String, Int], f: Int => BIO[String, Int]) =>
       fa.redeemWith(BIO.raiseError, f) <-> fa.flatMap(f)
     }
   }
 
   test("redeemWith derives onErrorHandleWith") { implicit s =>
-    check2 { (fa: Task[Int], f: Throwable => Task[Int]) =>
+    check2 { (fa: BIO[String, Int], f: String => BIO[String, Int]) =>
       fa.redeemWith(f, BIO.pure) <-> fa.onErrorHandleWith(f)
     }
   }
 
   test("redeem derives map . onErrorHandle") { implicit s =>
-    check2 { (fa: Task[Int], f: Int => Int) =>
-      fa.redeem(e => throw e, f) <-> fa.map(f).onErrorHandle(e => throw e)
+    check2 { (fa: BIO[String, Int], f: Int => Int) =>
+      fa.redeem(e => throw DummyException(e), f) <-> fa.map(f).onErrorHandle(e => throw DummyException(e))
     }
   }
 
   test("redeem derives onErrorHandle") { implicit s =>
-    check2 { (fa: Task[Int], f: Throwable => Int) =>
+    check2 { (fa: BIO[String, Int], f: String => Int) =>
       fa.redeem(f, x => x) <-> fa.onErrorHandle(f)
     }
   }
 
   test("redeemWith can recover") { implicit s =>
-    val dummy = new DummyException("dummy")
+    val dummy = "dummy"
     val task = BIO.raiseError(dummy).redeemWith(_ => BIO.now(1), BIO.now)
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Right(1))))
   }
 
   test("redeem can recover") { implicit s =>
-    val dummy = DummyException("dummy")
+    val dummy = "dummy"
     val task: UIO[Int] = BIO.raiseError(dummy).redeem(_ => 1, identity)
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Right(1))))
@@ -143,7 +143,7 @@ object TaskFlatMapSuite extends BaseTestSuite {
 
   test(">> is stack safe for infinite loops") { implicit s =>
     var wasCancelled = false
-    def looped: Task[Unit] = BIO.cancelBoundary >> looped
+    def looped: UIO[Unit] = BIO.cancelBoundary >> looped
     val future = looped.doOnCancel(UIO { wasCancelled = true }).runToFuture
     future.cancel()
     s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskFromFutureEitherSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskFromFutureEitherSuite.scala
@@ -61,7 +61,7 @@ object TaskFromFutureEitherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("BIO.fromFutureEither should work onFatalError") { implicit s =>
+  test("BIO.fromFutureEither should work onTermination") { implicit s =>
     val dummy = DummyException("dummy")
     val t = BIO.fromFutureEither(Future(throw dummy))
     val f = t.runToFuture
@@ -85,7 +85,7 @@ object TaskFromFutureEitherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left("dummy"))))
   }
 
-  test("BIO.fromFutureEither should be short-circuited onFatalError") { implicit s =>
+  test("BIO.fromFutureEither should be short-circuited onTermination") { implicit s =>
     val dummy = DummyException("dummy")
     val p = Promise[Either[String, Int]]()
     val t = BIO.fromFutureEither(p.future)
@@ -131,7 +131,7 @@ object TaskFromFutureEitherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("BIO.fromFutureEither(cancelable) should be short-circuited onFatalError") { implicit s =>
+  test("BIO.fromFutureEither(cancelable) should be short-circuited onTermination") { implicit s =>
     val dummy = DummyException("dummy")
     val p = Promise[Either[String, Int]]()
     val t = BIO.fromFutureEither(CancelableFuture(p.future, Cancelable.empty))
@@ -159,7 +159,7 @@ object TaskFromFutureEitherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("BIO.fromFutureEither(cancelable) should work onFatalError") { implicit s =>
+  test("BIO.fromFutureEither(cancelable) should work onTermination") { implicit s =>
     val dummy = DummyException("dummy")
     val p = Promise[Either[String, Int]]()
     val t = BIO.fromFutureEither(CancelableFuture(p.future, Cancelable.empty))

--- a/core/shared/src/test/scala/monix/bio/TaskGatherNSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskGatherNSuite.scala
@@ -17,18 +17,19 @@
 
 package monix.bio
 
+import cats.effect.ExitCase
 import monix.execution.atomic.AtomicInt
-import monix.execution.exceptions.DummyException
+import monix.execution.exceptions.{DummyException, UncaughtErrorException}
 import monix.execution.internal.Platform
 
 import scala.concurrent.duration._
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskGatherNSuite extends BaseTestSuite {
 
-  test("Task.gatherN should execute in parallel bounded by parallelism") { implicit s =>
+  test("BIO.gatherN should execute in parallel bounded by parallelism") { implicit s =>
     val num = AtomicInt(0)
-    val task = Task.evalAsync(num.increment()) >> Task.sleep(2.seconds)
+    val task = UIO.evalAsync(num.increment()) >> BIO.sleep(2.seconds)
     val seq = List.fill(100)(task)
 
     BIO.gatherN(5)(seq).runToFuture
@@ -43,22 +44,22 @@ object TaskGatherNSuite extends BaseTestSuite {
     assertEquals(num.get(), 100)
   }
 
-  test("Task.gatherN should return result in order") { implicit s =>
-    val task = 1.until(10).toList.map(Task.eval(_))
+  test("BIO.gatherN should return result in order") { implicit s =>
+    val task = 1.until(10).toList.map(UIO.eval(_))
     val res = BIO.gatherN(2)(task).runToFuture
 
     s.tick()
     assertEquals(res.value, Some(Success(Right(List(1, 2, 3, 4, 5, 6, 7, 8, 9)))))
   }
 
-  test("Task.gatherN should return empty list") { implicit s =>
+  test("BIO.gatherN should return empty list") { implicit s =>
     val res = BIO.gatherN(2)(List.empty).runToFuture
 
     s.tick()
     assertEquals(res.value, Some(Success(Right(List.empty))))
   }
 
-  test("Task.gatherN should handle single item") { implicit s =>
+  test("BIO.gatherN should handle single item") { implicit s =>
     val task = List(Task.eval(1))
     val res = BIO.gatherN(2)(task).runToFuture
 
@@ -66,21 +67,21 @@ object TaskGatherNSuite extends BaseTestSuite {
     assertEquals(res.value, Some(Success(Right(List(1)))))
   }
 
-  test("Task.gatherN should handle parallelism bigger than list") { implicit s =>
-    val task = 1.until(5).toList.map(Task.eval(_))
+  test("BIO.gatherN should handle parallelism bigger than list") { implicit s =>
+    val task = 1.until(5).toList.map(UIO.eval(_))
     val res = BIO.gatherN(10)(task).runToFuture
 
     s.tick()
     assertEquals(res.value, Some(Success(Right(List(1, 2, 3, 4)))))
   }
 
-  test("Task.gatherN should onError if one of the tasks terminates in error") { implicit s =>
-    val ex = DummyException("dummy")
+  test("BIO.gatherN should onError if one of the tasks terminates in error") { implicit s =>
+    val ex = "dummy"
     val seq = Seq(
-      Task.evalAsync(3).delayExecution(2.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(throw ex).delayExecution(2.seconds),
-      Task.evalAsync(3).delayExecution(1.seconds)
+      BIO.evalAsync(3).delayExecution(2.seconds),
+      BIO.evalAsync(2).delayExecution(1.second),
+      BIO.raiseError(ex).delayExecution(2.seconds),
+      BIO.evalAsync(3).delayExecution(1.seconds)
     )
 
     val f = BIO.gatherN(2)(seq).runToFuture
@@ -93,11 +94,30 @@ object TaskGatherNSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(ex))))
   }
 
-  test("Task.gatherN should be canceled") { implicit s =>
+  test("BIO.gatherN should onTerminate if one of the tasks terminates in a fatal error") { implicit s =>
+    val ex = DummyException("dummy")
+    val seq = Seq(
+      UIO.evalAsync(3).delayExecution(2.seconds),
+      UIO.evalAsync(2).delayExecution(1.second),
+      UIO.evalAsync(throw ex).delayExecution(2.seconds),
+      UIO.evalAsync(3).delayExecution(1.seconds)
+    )
+
+    val f = BIO.gatherN(2)(seq).runToFuture
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO.gatherN should be canceled") { implicit s =>
     val num = AtomicInt(0)
     val seq = Seq(
-      Task.unit.delayExecution(3.seconds).doOnCancel(UIO.eval(num.increment())),
-      Task.evalAsync(num.increment(10))
+      BIO.unit.delayExecution(3.seconds).doOnCancel(UIO.eval(num.increment())),
+      UIO.evalAsync(num.increment(10))
     )
     val f = BIO.gatherN(1)(seq).runToFuture
 
@@ -109,7 +129,7 @@ object TaskGatherNSuite extends BaseTestSuite {
     assertEquals(num.get(), 1)
   }
 
-  test("Task.gatherN should be stack safe for synchronous tasks") { implicit s =>
+  test("BIO.gatherN should be stack safe for synchronous tasks") { implicit s =>
     val count = if (Platform.isJVM) 200000 else 5000
     val tasks = for (_ <- 0 until count) yield Task.now(1)
     val composite = BIO.gatherN(count)(tasks).map(_.sum)
@@ -118,7 +138,7 @@ object TaskGatherNSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(Right(count))))
   }
 
-  test("Task.gatherN runAsync multiple times") { implicit s =>
+  test("BIO.gatherN runAsync multiple times") { implicit s =>
     var effect = 0
     val task1 = UIO.evalAsync { effect += 1; 3 }.memoize
     val task2 = task1 map { x =>
@@ -133,5 +153,75 @@ object TaskGatherNSuite extends BaseTestSuite {
     val result2 = task3.runToFuture; s.tick()
     assertEquals(result2.value, Some(Success(Right(List(4, 4, 4)))))
     assertEquals(effect, 1 + 3 + 3)
+  }
+
+  test("BIO.gatherN should log errors if multiple errors happen") { implicit s =>
+    implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
+
+    val ex = "dummy1"
+    var errorsThrow = 0
+
+    val task1: BIO[String, Int] = BIO
+      .raiseError(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val task2: BIO[String, Int] = BIO
+      .raiseError(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val gather = BIO.gatherN(4)(Seq(task1, task2))
+    val result = gather.runToFutureOpt
+    s.tick()
+
+    assertEquals(result.value, Some(Success(Left(ex))))
+    assertEquals(s.state.lastReportedError.toString, UncaughtErrorException.wrap(ex).toString)
+    assertEquals(errorsThrow, 2)
+  }
+
+  test("BIO.gatherN should log terminal errors if multiple errors happen") { implicit s =>
+    implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
+
+    val ex = DummyException("dummy1")
+    var errorsThrow = 0
+
+    val task1: BIO[String, Int] = BIO
+      .terminate(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val task2: BIO[String, Int] = BIO
+      .terminate(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val gather = BIO.gatherN(4)(Seq(task1, task2))
+    val result = gather.runToFutureOpt
+    s.tick()
+
+    assertEquals(result.value, Some(Failure(ex)))
+    assertEquals(s.state.lastReportedError, ex)
+    assertEquals(errorsThrow, 2)
   }
 }

--- a/core/shared/src/test/scala/monix/bio/TaskGatherSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskGatherSuite.scala
@@ -17,18 +17,19 @@
 
 package monix.bio
 
-import monix.execution.exceptions.DummyException
+import cats.effect.ExitCase
+import monix.execution.exceptions.{DummyException, UncaughtErrorException}
 import monix.execution.internal.Platform
 
 import scala.concurrent.duration._
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskGatherSuite extends BaseTestSuite {
-  test("Task.gather should execute in parallel for async tasks") { implicit s =>
+  test("BIO.gather should execute in parallel for async tasks") { implicit s =>
     val seq = Seq(
-      Task.evalAsync(1).delayExecution(2.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(3).delayExecution(3.seconds)
+      BIO.evalAsync(1).delayExecution(2.seconds),
+      BIO.evalAsync(2).delayExecution(1.second),
+      BIO.evalAsync(3).delayExecution(3.seconds)
     )
     val f = BIO.gather(seq).runToFuture
 
@@ -40,13 +41,13 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(Seq(1, 2, 3)))))
   }
 
-  test("Task.gather should onError if one of the tasks terminates in error") { implicit s =>
-    val ex = DummyException("dummy")
+  test("BIO.gather should onError if one of the tasks terminates in error") { implicit s =>
+    val ex = "dummy"
     val seq = Seq(
-      Task.evalAsync(3).delayExecution(3.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(throw ex).delayExecution(2.seconds),
-      Task.evalAsync(3).delayExecution(1.seconds)
+      UIO.evalAsync(3).delayExecution(3.seconds),
+      UIO.evalAsync(2).delayExecution(1.second),
+      BIO.raiseError(ex).delayExecution(2.seconds),
+      UIO.evalAsync(3).delayExecution(1.seconds)
     )
 
     val f = BIO.gather(seq).runToFuture
@@ -57,11 +58,28 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(ex))))
   }
 
-  test("Task.gather should be canceled") { implicit s =>
-    val seq = Seq(
-      Task.evalAsync(1).delayExecution(2.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(3).delayExecution(3.seconds)
+  test("BIO.gather should onTerminate if one of the tasks terminates in a fatal error") { implicit s =>
+    val ex = DummyException("dummy")
+    val seq: Seq[BIO[String, Int]] = Seq(
+      UIO.evalAsync(3).delayExecution(3.seconds),
+      UIO.evalAsync(2).delayExecution(1.second),
+      UIO.evalAsync(throw ex).delayExecution(2.seconds),
+      UIO.evalAsync(3).delayExecution(1.seconds)
+    )
+
+    val f = BIO.gather(seq).runToFuture
+
+    s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO.gather should be canceled") { implicit s =>
+    val seq: Seq[BIO[Int, Int]] = Seq(
+      UIO.evalAsync(1).delayExecution(2.seconds),
+      UIO.evalAsync(2).delayExecution(1.second),
+      UIO.evalAsync(3).delayExecution(3.seconds)
     )
     val f = BIO.gather(seq).runToFuture
 
@@ -75,7 +93,7 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.gather should be stack safe for synchronous tasks") { implicit s =>
+  test("BIO.gather should be stack safe for synchronous tasks") { implicit s =>
     val count = if (Platform.isJVM) 200000 else 5000
     val tasks = for (_ <- 0 until count) yield Task.now(1)
     val composite = BIO.gather(tasks).map(_.sum)
@@ -84,13 +102,13 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(Right(count))))
   }
 
-  test("Task.gather runAsync multiple times") { implicit s =>
+  test("BIO.gather runAsync multiple times") { implicit s =>
     var effect = 0
-    val task1 = BIO.evalAsync { effect += 1; 3 }.memoize
+    val task1 = UIO.evalAsync { effect += 1; 3 }.memoize
     val task2 = task1 map { x =>
       effect += 1; x + 1
     }
-    val task3 = BIO.gather(List(task2, task2, task2))
+    val task3 = UIO.gather(List(task2, task2, task2))
 
     val result1 = task3.runToFuture; s.tick()
     assertEquals(result1.value, Some(Success(Right(List(4, 4, 4)))))
@@ -99,5 +117,75 @@ object TaskGatherSuite extends BaseTestSuite {
     val result2 = task3.runToFuture; s.tick()
     assertEquals(result2.value, Some(Success(Right(List(4, 4, 4)))))
     assertEquals(effect, 1 + 3 + 3)
+  }
+
+  test("BIO.gather should log errors if multiple errors happen") { implicit s =>
+    implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
+
+    val ex = "dummy1"
+    var errorsThrow = 0
+
+    val task1: BIO[String, Int] = BIO
+      .raiseError(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val task2: BIO[String, Int] = BIO
+      .raiseError(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val gather = BIO.gather(Seq(task1, task2))
+    val result = gather.runToFutureOpt
+    s.tick()
+
+    assertEquals(result.value, Some(Success(Left(ex))))
+    assertEquals(s.state.lastReportedError.toString, UncaughtErrorException.wrap(ex).toString)
+    assertEquals(errorsThrow, 2)
+  }
+
+  test("BIO.gather should log terminal errors if multiple errors happen") { implicit s =>
+    implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
+
+    val ex = DummyException("dummy1")
+    var errorsThrow = 0
+
+    val task1: BIO[String, Int] = BIO
+      .terminate(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val task2: BIO[String, Int] = BIO
+      .terminate(ex)
+      .executeAsync
+      .guaranteeCase {
+        case ExitCase.Completed => BIO.unit
+        case ExitCase.Error(_) => UIO(errorsThrow += 1)
+        case ExitCase.Canceled => BIO.unit
+      }
+      .uncancelable
+
+    val gather = BIO.gather(Seq(task1, task2))
+    val result = gather.runToFutureOpt
+    s.tick()
+
+    assertEquals(result.value, Some(Failure(ex)))
+    assertEquals(s.state.lastReportedError, ex)
+    assertEquals(errorsThrow, 2)
   }
 }

--- a/core/shared/src/test/scala/monix/bio/TaskGatherUnorderedSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskGatherUnorderedSuite.scala
@@ -121,7 +121,7 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
     gatherSpecial(tasks)
       .map(_.sum)
       .runAsync(new BiCallback[Cause[Throwable], Int] {
-        override def onFatalError(e: Throwable): Unit =
+        override def onTermination(e: Throwable): Unit =
           result = Some(Failure(e))
 
         override def onSuccess(value: Int): Unit =

--- a/core/shared/src/test/scala/monix/bio/TaskGuaranteeSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskGuaranteeSuite.scala
@@ -63,7 +63,7 @@ object TaskGuaranteeSuite extends BaseTestSuite {
   test("if finalizer throws, report finalizer error and signal use error") { implicit sc =>
     val useError = DummyException("useError")
     val finalizerError = DummyException("finalizerError")
-    val task = Task.raiseError(useError).guarantee(BIO.raiseFatalError(finalizerError))
+    val task = Task.raiseError(useError).guarantee(BIO.terminate(finalizerError))
 
     val result = task.runToFuture
     sc.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskMapBothSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMapBothSuite.scala
@@ -128,11 +128,11 @@ object TaskMapBothSuite extends BaseTestSuite {
     }
   }
 
-  test("both task can fail with fatal error") { implicit s =>
+  test("both task can fail with terminal error") { implicit s =>
     val err1 = new RuntimeException("Error 1")
-    val t1: Task[Int] = Task.defer(Task.raiseFatalError(err1)).executeAsync
+    val t1: Task[Int] = Task.defer(Task.terminate(err1)).executeAsync
     val err2 = new RuntimeException("Error 2")
-    val t2: Task[Int] = Task.defer(Task.raiseFatalError(err2)).executeAsync
+    val t2: Task[Int] = Task.defer(Task.terminate(err2)).executeAsync
 
     val fb = BIO
       .mapBoth(t1, t2)(_ + _)

--- a/core/shared/src/test/scala/monix/bio/TaskMapBothSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMapBothSuite.scala
@@ -108,9 +108,9 @@ object TaskMapBothSuite extends BaseTestSuite {
 
   test("both task can fail with error") { implicit s =>
     val err1 = new RuntimeException("Error 1")
-    val t1 = Task.defer(Task.raiseError[Int](err1)).executeAsync
+    val t1 = BIO.defer(Task.raiseError[Int](err1)).executeAsync
     val err2 = new RuntimeException("Error 2")
-    val t2 = Task.defer(Task.raiseError[Int](err2)).executeAsync
+    val t2 = BIO.defer(Task.raiseError[Int](err2)).executeAsync
 
     val fb = BIO
       .mapBoth(t1, t2)(_ + _)
@@ -130,9 +130,9 @@ object TaskMapBothSuite extends BaseTestSuite {
 
   test("both task can fail with terminal error") { implicit s =>
     val err1 = new RuntimeException("Error 1")
-    val t1: Task[Int] = Task.defer(Task.terminate(err1)).executeAsync
+    val t1: UIO[Int] = UIO.defer(BIO.terminate(err1)).executeAsync
     val err2 = new RuntimeException("Error 2")
-    val t2: Task[Int] = Task.defer(Task.terminate(err2)).executeAsync
+    val t2: UIO[Int] = UIO.defer(BIO.terminate(err2)).executeAsync
 
     val fb = BIO
       .mapBoth(t1, t2)(_ + _)

--- a/core/shared/src/test/scala/monix/bio/TaskMaterializeSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMaterializeSuite.scala
@@ -32,9 +32,9 @@ object TaskMaterializeSuite extends BaseTestSuite {
     assertEquals(BIO.raiseError(dummy).materialize.runToFuture.value, Some(Success(Right(Success(Left(dummy))))))
   }
 
-  test("BIO.fatalError.materialize") { implicit s =>
+  test("BIO.terminate.materialize") { implicit s =>
     val dummy = DummyException("dummy")
-    assertEquals(BIO.raiseFatalError(dummy).materialize.runToFuture.value, Some(Success(Right(Failure(dummy)))))
+    assertEquals(BIO.terminate(dummy).materialize.runToFuture.value, Some(Success(Right(Failure(dummy)))))
   }
 
   //  test("Task.evalOnce.materialize") { implicit s =>
@@ -183,7 +183,7 @@ object TaskMaterializeSuite extends BaseTestSuite {
         (BIO.now(n): BIO[String, Int]).materialize.flatMap {
           case Success(Right(v)) => loop(v - 1)
           case Success(Left(ex)) => BIO.raiseError(ex)
-          case Failure(ex) => BIO.raiseFatalError(ex)
+          case Failure(ex) => BIO.terminate(ex)
         }
 
     val count = if (Platform.isJVM) 50000 else 5000
@@ -197,9 +197,9 @@ object TaskMaterializeSuite extends BaseTestSuite {
     assertEquals(result.value, Some(Success(Left(ex))))
   }
 
-  test("BIO.raiseFatalError.dematerialize") { implicit s =>
+  test("BIO.terminate.dematerialize") { implicit s =>
     val ex = DummyException("dummy")
-    val result = BIO.raiseFatalError(ex).materialize.dematerialize.runToFuture
+    val result = BIO.terminate(ex).materialize.dematerialize.runToFuture
     assertEquals(result.value, Some(Failure(ex)))
   }
 

--- a/core/shared/src/test/scala/monix/bio/TaskMemoizeOnSuccessSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMemoizeOnSuccessSuite.scala
@@ -599,32 +599,32 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     assertEquals(effect, 2)
   }
 
-  test("BIO.eval.memoizeOnSuccess eq Task.eval.memoizeOnSuccess.memoizeOnSuccess") { implicit s =>
+  test("BIO.eval.memoizeOnSuccess eq BIO.eval.memoizeOnSuccess.memoizeOnSuccess") { implicit s =>
     val task = BIO.eval(1).memoizeOnSuccess
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.eval.memoize eq Task.eval.memoize.memoizeOnSuccess") { implicit s =>
+  test("BIO.eval.memoize eq BIO.eval.memoize.memoizeOnSuccess") { implicit s =>
     val task = BIO.eval(1).memoize
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.eval.map.memoize eq Task.eval.map.memoize.memoizeOnSuccess") { implicit s =>
+  test("BIO.eval.map.memoize eq BIO.eval.map.memoize.memoizeOnSuccess") { implicit s =>
     val task = BIO.eval(1).map(_ + 1).memoize
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.now.memoizeOnSuccess eq Task.now") { implicit s =>
+  test("BIO.now.memoizeOnSuccess eq BIO.now") { implicit s =>
     val task = BIO.now(1)
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.raiseError.memoizeOnSuccess eq Task.raiseError") { implicit s =>
+  test("BIO.raiseError.memoizeOnSuccess eq BIO.raiseError") { implicit s =>
     val task = BIO.raiseError("dummy")
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.terminate.memoizeOnSuccess eq Task.raiseError") { implicit s =>
+  test("BIO.terminate.memoizeOnSuccess eq BIO.terminate") { implicit s =>
     val task = BIO.terminate(DummyException("dummy"))
     assertEquals(task, task.memoizeOnSuccess)
   }

--- a/core/shared/src/test/scala/monix/bio/TaskMemoizeOnSuccessSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMemoizeOnSuccessSuite.scala
@@ -18,7 +18,6 @@
 package monix.bio
 
 import monix.bio.internal.BiCallback
-import monix.execution.exceptions.UncaughtErrorException
 import monix.execution.exceptions.DummyException
 import monix.execution.internal.Platform
 
@@ -110,11 +109,11 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     assertEquals(effect, 2)
   }
 
-  test("BIO.raiseFatalError(error).memoizeOnSuccess should not be idempotent") { implicit s =>
+  test("BIO.terminate(error).memoizeOnSuccess should not be idempotent") { implicit s =>
     var effect = 0
     val dummy = DummyException("dummy")
     val task = BIO
-      .suspendTotal(BIO.raiseFatalError { effect += 1; dummy })
+      .suspendTotal(BIO.terminate { effect += 1; dummy })
       .memoizeOnSuccess
       .flatMap(BIO.now[Int])
       .flatMap(BIO.now[Int])
@@ -141,9 +140,9 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(Success(Left(dummy))))))
   }
 
-  test("BIO.raiseFatalError(error).memoizeOnSuccess.materialize") { implicit s =>
+  test("BIO.terminate(error).memoizeOnSuccess.materialize") { implicit s =>
     val dummy = DummyException("dummy")
-    val f = BIO.raiseFatalError(dummy).memoizeOnSuccess.materialize.runToFuture
+    val f = BIO.terminate(dummy).memoizeOnSuccess.materialize.runToFuture
     s.tick()
     assertEquals(f.value, Some(Success(Right(Failure(dummy)))))
   }
@@ -264,9 +263,9 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     assertEquals(f2.value, Some(Success(Left(dummy))))
   }
 
-  test("BIO.raiseFatalError.memoizeOnSuccess should work") { implicit s =>
+  test("BIO.terminate.memoizeOnSuccess should work") { implicit s =>
     val dummy = DummyException("dummy")
-    val task = BIO.raiseFatalError(dummy).memoizeOnSuccess
+    val task = BIO.terminate(dummy).memoizeOnSuccess
 
     val f1 = task.runToFuture
     assertEquals(f1.value, Some(Failure(dummy)))
@@ -625,8 +624,8 @@ object TaskMemoizeOnSuccessSuite extends BaseTestSuite {
     assertEquals(task, task.memoizeOnSuccess)
   }
 
-  test("BIO.raiseFatalError.memoizeOnSuccess eq Task.raiseError") { implicit s =>
-    val task = BIO.raiseFatalError(DummyException("dummy"))
+  test("BIO.terminate.memoizeOnSuccess eq Task.raiseError") { implicit s =>
+    val task = BIO.terminate(DummyException("dummy"))
     assertEquals(task, task.memoizeOnSuccess)
   }
 }

--- a/core/shared/src/test/scala/monix/bio/TaskMemoizeSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMemoizeSuite.scala
@@ -99,10 +99,10 @@ object TaskMemoizeSuite extends BaseTestSuite {
     assertEquals(effect, 1)
   }
 
-  test("BIO.raiseFatalError(error).memoize should work") { implicit s =>
+  test("BIO.terminate(error).memoize should work") { implicit s =>
     var effect = 0
     val dummy = DummyException("dummy")
-    val task = BIO.raiseFatalError { effect += 1; dummy }.memoize
+    val task = BIO.terminate { effect += 1; dummy }.memoize
       .flatMap(BIO.now[Int])
       .flatMap(BIO.now[Int])
 
@@ -604,8 +604,8 @@ object TaskMemoizeSuite extends BaseTestSuite {
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.raiseFatalError.memoize eq Task.raiseError") { implicit s =>
-    val task = BIO.raiseFatalError(DummyException("dummy"))
+  test("BIO.terminate.memoize eq Task.raiseError") { implicit s =>
+    val task = BIO.terminate(DummyException("dummy"))
     assertEquals(task, task.memoize)
   }
 

--- a/core/shared/src/test/scala/monix/bio/TaskMemoizeSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMemoizeSuite.scala
@@ -584,32 +584,32 @@ object TaskMemoizeSuite extends BaseTestSuite {
     assertEquals(effect, 1)
   }
 
-  test("BIO.eval.memoize eq Task.eval.memoize.memoize") { implicit s =>
+  test("BIO.eval.memoize eq BIO.eval.memoize.memoize") { implicit s =>
     val task = BIO.eval(1).memoize
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.eval.map.memoize eq Task.eval.map.memoize.memoize") { implicit s =>
+  test("BIO.eval.map.memoize eq BIO.eval.map.memoize.memoize") { implicit s =>
     val task = BIO.eval(1).map(_ + 1).memoize
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.now.memoize eq Task.now") { implicit s =>
+  test("BIO.now.memoize eq BIO.now") { implicit s =>
     val task = BIO.now(1)
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.raiseError.memoize eq Task.raiseError") { implicit s =>
+  test("BIO.raiseError.memoize eq BIO.raiseError") { implicit s =>
     val task = BIO.raiseError("dummy")
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.terminate.memoize eq Task.raiseError") { implicit s =>
+  test("BIO.terminate.memoize eq BIO.raiseError") { implicit s =>
     val task = BIO.terminate(DummyException("dummy"))
     assertEquals(task, task.memoize)
   }
 
-  test("BIO.eval.memoizeOnSuccess.memoize !== Task.eval.memoizeOnSuccess") { implicit s =>
+  test("BIO.eval.memoizeOnSuccess.memoize !== BIO.eval.memoizeOnSuccess") { implicit s =>
     val task = BIO.eval(1).memoizeOnSuccess
     assert(task != task.memoize, "task != task.memoize")
   }

--- a/core/shared/src/test/scala/monix/bio/TaskMiscSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMiscSuite.scala
@@ -18,6 +18,7 @@
 package monix.bio
 
 import cats.syntax.either._
+import monix.bio.internal.BiCallback
 import monix.execution.exceptions.DummyException
 import org.reactivestreams.{Subscriber, Subscription}
 
@@ -26,31 +27,38 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object TaskMiscSuite extends BaseTestSuite {
-  test("Task.attempt should succeed") { implicit s =>
-    val result = Task.now(1).attempt.runToFuture
+  test("BIO.attempt should succeed") { implicit s =>
+    val result = BIO.now(1).attempt.runToFuture
     assertEquals(result.value, Some(Success(Right(Right(1)))))
   }
 
-  test("Task.raiseError.attempt should expose error") { implicit s =>
-    val ex = DummyException("dummy")
-    val result = Task.raiseError[Int](ex).attempt.runToFuture.map(_.flatMap(identity))
+  test("BIO.raiseError.attempt should expose error") { implicit s =>
+    val ex = 1204
+    val result = BIO.raiseError(ex).attempt.runToFuture.map(_.flatMap(identity))
     s.tickOne()
     assertEquals(result.value, Some(Success(Left(ex))))
   }
 
-  test("Task.tapError should not alter original successful value") { implicit s =>
+  test("BIO.terminate.attempt should not expose error") { implicit s =>
+    val ex = DummyException("dummy")
+    val result = BIO.terminate(ex).attempt.runToFuture.map(_.flatMap(identity))
+    s.tickOne()
+    assertEquals(result.value, Some(Failure(ex)))
+  }
+
+  test("BIO.tapError should not alter original successful value") { implicit s =>
     val result = BIO.fromEither[String, Int](1.asRight).tapError(e => BIO.raiseError(e)).runToFuture
     assertEquals(result.value, Some(Success(Right(1))))
   }
 
-  test("Task.tapError should not alter original error value") { implicit s =>
+  test("BIO.tapError should not alter original error value") { implicit s =>
     var effect = 0
     val result = BIO.fromEither[String, Int]("Error".asLeft).tapError(_ => BIO.delay(effect += 1)).runToFuture
     assertEquals(result.value, Some(Success(Left("Error"))))
     assertEquals(effect, 1)
   }
 
-  test("Task.tapError should not alter original terminal error") { implicit s =>
+  test("BIO.tapError should not alter original terminal error") { implicit s =>
     var effect = 0
     val ex = DummyException("dummy")
     val result = BIO.terminate(ex).tapError(_ => BIO.delay(effect += 1)).runToFuture
@@ -58,29 +66,29 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(effect, 0)
   }
 
-  test("Task.fail should expose error") { implicit s =>
+  test("BIO.failed should expose error") { implicit s =>
     val dummy = DummyException("dummy")
-    val f = Task.raiseError(dummy).failed.runToFuture
+    val f = BIO.raiseError(dummy).failed.runToFuture
     assertEquals(f.value, Some(Success(Right(dummy))))
   }
 
-  test("Task.fail should fail for successful values") { implicit s =>
+  test("BIO.failed should fail for successful values") { implicit s =>
     intercept[NoSuchElementException] {
-      Task.eval(10).failed.runSyncStep
+      BIO.eval(10).failed.runSyncStep
     }
   }
 
-  test("Task.map protects against user code") { implicit s =>
+  test("BIO.map protects against user code") { implicit s =>
     val ex = DummyException("dummy")
-    val result = Task.now(1).map(_ => throw ex).runToFuture
+    val result = BIO.now(1).map(_ => throw ex).runToFuture
     assertEquals(result.value, Some(Failure(ex)))
   }
 
-  test("Task.forever") { implicit s =>
+  test("BIO.forever") { implicit s =>
     val ex = DummyException("dummy")
     var effect = 0
-    val result = Task.eval { if (effect < 10) effect += 1 else throw ex }.loopForever
-      .onErrorFallbackTo(Task.eval(effect))
+    val result = BIO.eval { if (effect < 10) effect += 1 else throw ex }.loopForever
+      .onErrorFallbackTo(BIO.eval(effect))
       .runToFuture
     assertEquals(result.value.get.get, Right(10))
   }
@@ -203,13 +211,13 @@ object TaskMiscSuite extends BaseTestSuite {
     assert(s.state.tasks.isEmpty, "should not have tasks left to execute")
   }
 
-  test("Task.pure is an alias of now") { implicit s =>
-    assertEquals(Task.pure(1), Task.now(1))
+  test("BIO.pure is an alias of now") { implicit s =>
+    assertEquals(BIO.pure(1), BIO.now(1))
   }
 
-  test("Task.now.runAsync with Try-based callback") { implicit s =>
+  test("BIO.now.runAsync with Try-based callback") { implicit s =>
     val p = Promise[Either[Int, Int]]()
-    BIO.now(1).runAsync {
+    (BIO.now(1): BIO[Int, Int]).runAsync {
       case Left(cause) => cause.fold(p.failure, t => p.success(Left(t)))
       case Right(v) => p.success(Right(v))
     }

--- a/core/shared/src/test/scala/monix/bio/TaskMiscSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskMiscSuite.scala
@@ -50,10 +50,10 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(effect, 1)
   }
 
-  test("Task.tapError should not alter original fatal error") { implicit s =>
+  test("Task.tapError should not alter original terminal error") { implicit s =>
     var effect = 0
     val ex = DummyException("dummy")
-    val result = BIO.raiseFatalError(ex).tapError(_ => BIO.delay(effect += 1)).runToFuture
+    val result = BIO.terminate(ex).tapError(_ => BIO.delay(effect += 1)).runToFuture
     assertEquals(result.value, Some(Failure(ex)))
     assertEquals(effect, 0)
   }
@@ -137,9 +137,9 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(received, expected)
   }
 
-  test("BIO.toReactivePublisher should convert tasks with fatal errors") { implicit s =>
+  test("BIO.toReactivePublisher should convert tasks with terminal errors") { implicit s =>
     val expected = DummyException("Error")
-    val publisher = BIO.raiseFatalError(expected).toReactivePublisher
+    val publisher = BIO.terminate(expected).toReactivePublisher
     var received: Throwable = null
 
     publisher.subscribe {
@@ -226,10 +226,10 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(p.future.value, Some(Success(Left(ex))))
   }
 
-  test("Task.fatalError.runAsync with Try-based callback") { implicit s =>
+  test("Task.terminate.runAsync with Try-based callback") { implicit s =>
     val ex = DummyException("dummy")
     val p = Promise[Either[Throwable, Int]]()
-    Task.raiseFatalError[Int](ex).runAsync {
+    Task.terminate[Int](ex).runAsync {
       case Left(cause) => cause.fold(p.failure, t => p.success(Left(t)))
       case Right(v) => p.success(Right(v))
     }
@@ -257,10 +257,10 @@ object TaskMiscSuite extends BaseTestSuite {
     assertEquals(p.future.value, Some(Success(Left(ex))))
   }
 
-  test("task.executeAsync.runAsync with Try-based callback for fatal error") { implicit s =>
+  test("task.executeAsync.runAsync with Try-based callback for terminal error") { implicit s =>
     val ex = DummyException("dummy")
     val p = Promise[Either[Throwable, Int]]()
-    Task.raiseFatalError[Int](ex).executeAsync.runAsync {
+    Task.terminate[Int](ex).executeAsync.runAsync {
       case Left(cause) => cause.fold(p.failure, t => p.success(Left(t)))
       case Right(v) => p.success(Right(v))
     }

--- a/core/shared/src/test/scala/monix/bio/TaskNowSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskNowSuite.scala
@@ -25,49 +25,49 @@ import monix.execution.exceptions.DummyException
 import scala.util.{Failure, Success, Try}
 
 object TaskNowSuite extends BaseTestSuite {
-  test("Task.now should work synchronously") { implicit s =>
+  test("BIO.now should work synchronously") { implicit s =>
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.now(trigger())
+    val task = BIO.now(trigger())
     assert(wasTriggered, "wasTriggered")
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Right("result"))))
   }
 
-  test("Task.now.runAsync: CancelableFuture should be synchronous for AlwaysAsyncExecution") { s =>
+  test("BIO.now.runAsync: CancelableFuture should be synchronous for AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.now(trigger())
+    val task = BIO.now(trigger())
     assert(wasTriggered, "wasTriggered")
 
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Right("result"))))
   }
 
-  test("Task.now.runAsync(callback) should work synchronously") { implicit s =>
+  test("BIO.now.runAsync(callback) should work synchronously") { implicit s =>
     var result = Option.empty[Try[String]]
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.now(trigger())
+    val task = BIO.now(trigger())
     assert(wasTriggered, "wasTriggered")
 
     task.runAsync(r => result = Some(r.left.map(_.fold(identity, identity)).toTry))
     assertEquals(result, Some(Success("result")))
   }
 
-  test("Task.now.runAsync(callback) should be asynchronous for AlwaysAsyncExecution") { s =>
+  test("BIO.now.runAsync(callback) should be asynchronous for AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
     var result = Option.empty[Try[String]]
     var wasTriggered = false
     def trigger(): String = { wasTriggered = true; "result" }
 
-    val task = Task.now(trigger())
+    val task = BIO.now(trigger())
     assert(wasTriggered, "wasTriggered")
 
     task.runAsync(r => result = Some(r.left.map(_.fold(identity, identity)).toTry))
@@ -76,45 +76,56 @@ object TaskNowSuite extends BaseTestSuite {
     assertEquals(result, Some(Success("result")))
   }
 
-  test("Task.raiseError should work synchronously") { implicit s =>
+  test("BIO.raiseError should work synchronously") { implicit s =>
     var wasTriggered = false
-    val dummy = DummyException("dummy")
-    def trigger(): Throwable = { wasTriggered = true; dummy }
+    val dummy = 1204
+    def trigger(): Int = { wasTriggered = true; dummy }
 
-    val task = Task.raiseError(trigger())
+    val task = BIO.raiseError(trigger())
     assert(wasTriggered, "wasTriggered")
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("Task.raiseError.runAsync: CancelableFuture should be synchronous for AlwaysAsyncExecution") { s =>
+  test("BIO.terminate should work synchronously") { implicit s =>
+    var wasTriggered = false
+    val dummy = DummyException("dummy")
+    def trigger(): Throwable = { wasTriggered = true; dummy }
+
+    val task = BIO.terminate(trigger())
+    assert(wasTriggered, "wasTriggered")
+    val f = task.runToFuture
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("BIO.raiseError.runAsync: CancelableFuture should be synchronous for AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
-    val dummy = DummyException("dummy")
+    val dummy = 1204
     var wasTriggered = false
-    def trigger(): Throwable = { wasTriggered = true; dummy }
+    def trigger(): Int = { wasTriggered = true; dummy }
 
-    val task = Task.raiseError[String](trigger())
+    val task = BIO.raiseError(trigger())
     assert(wasTriggered, "wasTriggered")
 
     val f = task.runToFuture
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("Task.raiseError.runAsync(callback) should work synchronously") { implicit s =>
+  test("BIO.raiseError.runAsync(callback) should work synchronously") { implicit s =>
     var result = Option.empty[Try[String]]
     val dummy = DummyException("dummy")
     var wasTriggered = false
     def trigger(): Throwable = { wasTriggered = true; dummy }
 
-    val task = Task.raiseError[String](trigger())
+    val task = BIO.raiseError(trigger())
     assert(wasTriggered, "wasTriggered")
 
     task.runAsync(r => result = Some(r.left.map(_.fold(identity, identity)).toTry))
     assertEquals(result, Some(Failure(dummy)))
   }
 
-  test("Task.raiseError.runAsync(callback) should be asynchronous for AlwaysAsyncExecution") { s =>
+  test("BIO.raiseError.runAsync(callback) should be asynchronous for AlwaysAsyncExecution") { s =>
     implicit val s2 = s.withExecutionModel(AlwaysAsyncExecution)
 
     val dummy = DummyException("dummy")
@@ -122,7 +133,7 @@ object TaskNowSuite extends BaseTestSuite {
     var wasTriggered = false
     def trigger(): Throwable = { wasTriggered = true; dummy }
 
-    val task = Task.raiseError[String](trigger())
+    val task = BIO.raiseError(trigger())
     assert(wasTriggered, "wasTriggered")
 
     task.runAsync(r => result = Some(r.left.map(_.fold(identity, identity)).toTry))
@@ -131,46 +142,46 @@ object TaskNowSuite extends BaseTestSuite {
     assertEquals(result, Some(Failure(dummy)))
   }
 
-  test("Task.now.map should work") { implicit s =>
+  test("BIO.now.map should work") { implicit s =>
     check1 { a: Int =>
-      Task.now(a).map(_ + 1) <-> Task.now(a + 1)
+      BIO.now(a).map(_ + 1) <-> BIO.now(a + 1)
     }
   }
 
-  test("Task.raiseError.map should be the same as Task.raiseError") { implicit s =>
+  test("BIO.raiseError.map should be the same as BIO.raiseError") { implicit s =>
     check {
       val dummy = DummyException("dummy")
-      Task.raiseError[Int](dummy).map(_ + 1) <-> Task.raiseError(dummy)
+      (BIO.raiseError(dummy): BIO[Throwable, Int]).map(_ + 1) <-> BIO.raiseError(dummy)
     }
   }
 
-  test("Task.raiseError.flatMap should be the same as Task.flatMap") { implicit s =>
+  test("BIO.raiseError.flatMap should be the same as BIO.flatMap") { implicit s =>
     check {
       val dummy = DummyException("dummy")
-      Task.raiseError[Int](dummy).flatMap(Task.now) <-> Task.raiseError(dummy)
+      (BIO.raiseError(dummy): BIO[Throwable, Int]).flatMap(BIO.now) <-> BIO.raiseError(dummy)
     }
   }
 
-  test("Task.raiseError.flatMap should be protected") { implicit s =>
+  test("BIO.raiseError.flatMap should be protected") { implicit s =>
     check {
       val dummy = DummyException("dummy")
       val err = DummyException("err")
-      Task.raiseError[Int](dummy).flatMap[Throwable, Int](_ => throw err) <-> Task.raiseError(dummy)
+      BIO.raiseError(dummy).flatMap[Throwable, Int](_ => throw err) <-> BIO.raiseError(dummy)
     }
   }
 
-  test("Task.now.flatMap should protect against user code") { implicit s =>
+  test("BIO.now.flatMap should protect against user code") { implicit s =>
     val ex = DummyException("dummy")
     val t = BIO.now(1).flatMap[String, Int](_ => throw ex)
     check(t <-> BIO.terminate(ex))
   }
 
-  test("Task.now.flatMap should be tail recursive") { implicit s =>
-    def loop(n: Int, idx: Int): Task[Int] =
-      Task.now(idx).flatMap { a =>
+  test("BIO.now.flatMap should be tail recursive") { implicit s =>
+    def loop(n: Int, idx: Int): UIO[Int] =
+      BIO.now(idx).flatMap { _ =>
         if (idx < n) loop(n, idx + 1).map(_ + 1)
         else
-          Task.now(idx)
+          BIO.now(idx)
       }
 
     val iterations = s.executionModel.recommendedBatchSize * 20
@@ -182,31 +193,40 @@ object TaskNowSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(iterations * 2))))
   }
 
-  test("Task.now should not be cancelable") { implicit s =>
-    val t = Task.now(10)
+  test("BIO.now should not be cancelable") { implicit s =>
+    val t = BIO.now(10)
     val f = t.runToFuture
     f.cancel()
     s.tick()
     assertEquals(f.value, Some(Success(Right(10))))
   }
 
-  test("Task.raiseError should not be cancelable") { implicit s =>
-    val dummy = DummyException("dummy")
-    val t = Task.raiseError(dummy)
+  test("BIO.raiseError should not be cancelable") { implicit s =>
+    val dummy = 1453
+    val t = BIO.raiseError(dummy)
     val f = t.runToFuture
     f.cancel()
     s.tick()
     assertEquals(f.value, Some(Success(Left(dummy))))
   }
 
-  test("Task.now.coeval") { implicit s =>
-    val result = Task.now(100).runSyncStep
+  test("BIO.terminate should not be cancelable") { implicit s =>
+    val dummy = DummyException("dummy")
+    val t = BIO.terminate(dummy)
+    val f = t.runToFuture
+    f.cancel()
+    s.tick()
+    assertEquals(f.value, Some(Failure(dummy)))
+  }
+
+  test("BIO.now.runSyncStep") { implicit s =>
+    val result = BIO.now(100).runSyncStep
     assertEquals(result, Right(100))
   }
 
-  test("Task.raiseError.coeval") { implicit s =>
-    val dummy = DummyException("dummy")
-    val result = Task.raiseError(dummy).attempt.runSyncStep
+  test("BIO.raiseError.runSyncStep") { implicit s =>
+    val dummy = 10000
+    val result = BIO.raiseError(dummy).attempt.runSyncStep
     assertEquals(result, Right(Left(dummy)))
   }
 }

--- a/core/shared/src/test/scala/monix/bio/TaskNowSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskNowSuite.scala
@@ -162,7 +162,7 @@ object TaskNowSuite extends BaseTestSuite {
   test("Task.now.flatMap should protect against user code") { implicit s =>
     val ex = DummyException("dummy")
     val t = BIO.now(1).flatMap[String, Int](_ => throw ex)
-    check(t <-> BIO.raiseFatalError(ex))
+    check(t <-> BIO.terminate(ex))
   }
 
   test("Task.now.flatMap should be tail recursive") { implicit s =>

--- a/core/shared/src/test/scala/monix/bio/TaskRaceSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskRaceSuite.scala
@@ -157,7 +157,7 @@ object TaskRaceSuite extends BaseTestSuite {
     assert(s.state.tasks.isEmpty, "timer should be canceled")
   }
 
-  test("Task#timeout should mirror the source in case of fatal error") { implicit s =>
+  test("Task#timeout should mirror the source in case of terminal error") { implicit s =>
     val ex = DummyException("dummy")
     val task = Task.evalAsync(throw ex).hideErrors.delayExecution(1.seconds).timeout(10.second)
     val f = task.runToFuture

--- a/core/shared/src/test/scala/monix/bio/TaskSequenceSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskSequenceSuite.scala
@@ -20,14 +20,14 @@ package monix.bio
 import monix.execution.exceptions.DummyException
 
 import scala.concurrent.duration._
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 object TaskSequenceSuite extends BaseTestSuite {
-  test("Task.sequence should not execute in parallel") { implicit s =>
+  test("BIO.sequence should not execute in parallel") { implicit s =>
     val seq = Seq(
-      Task.evalAsync(1).delayExecution(2.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(3).delayExecution(3.seconds)
+      BIO.evalAsync(1).delayExecution(2.seconds),
+      BIO.evalAsync(2).delayExecution(1.second),
+      BIO.evalAsync(3).delayExecution(3.seconds)
     )
     val f = BIO.sequence(seq).runToFuture
 
@@ -41,13 +41,13 @@ object TaskSequenceSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(Seq(1, 2, 3)))))
   }
 
-  test("Task.sequence should onError if one of the tasks terminates in error") { implicit s =>
+  test("BIO.sequence should onError if one of the tasks terminates in error") { implicit s =>
     val ex = DummyException("dummy")
     val seq = Seq(
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(throw ex).delayExecution(2.seconds),
-      Task.evalAsync(3).delayExecution(3.seconds),
-      Task.evalAsync(3).delayExecution(1.seconds)
+      BIO.evalAsync(2).delayExecution(1.second),
+      BIO.evalAsync(throw ex).delayExecution(2.seconds),
+      BIO.evalAsync(3).delayExecution(3.seconds),
+      BIO.evalAsync(3).delayExecution(1.seconds)
     )
 
     val f = BIO.sequence(seq).runToFuture
@@ -60,11 +60,30 @@ object TaskSequenceSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(ex))))
   }
 
-  test("Task.sequence should be canceled") { implicit s =>
+  test("BIO.sequence should onTerminate if one of the tasks terminates in error") { implicit s =>
+    val ex = DummyException("dummy")
     val seq = Seq(
-      Task.evalAsync(1).delayExecution(2.seconds),
-      Task.evalAsync(2).delayExecution(1.second),
-      Task.evalAsync(3).delayExecution(3.seconds)
+      UIO.evalAsync(2).delayExecution(1.second),
+      UIO.evalAsync(throw ex).delayExecution(2.seconds),
+      UIO.evalAsync(3).delayExecution(3.seconds),
+      UIO.evalAsync(3).delayExecution(1.seconds)
+    )
+
+    val f = UIO.sequence(seq).runToFuture
+
+    // First
+    s.tick(1.second)
+    assertEquals(f.value, None)
+    // Second
+    s.tick(2.second)
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("BIO.sequence should be canceled") { implicit s =>
+    val seq = Seq(
+      BIO.evalAsync(1).delayExecution(2.seconds),
+      BIO.evalAsync(2).delayExecution(1.second),
+      BIO.evalAsync(3).delayExecution(3.seconds)
     )
     val f = BIO.sequence(seq).runToFuture
 

--- a/core/shared/src/test/scala/monix/bio/TaskSuspendSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskSuspendSuite.scala
@@ -46,7 +46,7 @@ object TaskSuspendSuite extends BaseTestSuite {
 
   test("BIO.suspendTotal should protect against unexpected errors") { implicit s =>
     val ex = DummyException("dummy")
-    val f = BIO.suspendTotal[Int, Int](throw ex).redeemFatal(_ => 10, identity).runToFuture
+    val f = BIO.suspendTotal[Int, Int](throw ex).redeemCause(_ => 10, identity).runToFuture
     val g = BIO.suspendTotal[Int, Int](throw ex).onErrorHandle(_ => 10).runToFuture
 
     assertEquals(f.value, Some(Success(Right(10))))

--- a/core/shared/src/test/scala/monix/bio/TaskTerminationSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskTerminationSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.bio
+
+import monix.execution.exceptions.DummyException
+import cats.laws._
+import cats.laws.discipline._
+import scala.util.{Failure, Success}
+
+object TaskTerminationSuite extends BaseTestSuite {
+  test("BIO#redeemCause should mirror source on success") { implicit s =>
+    val task = (UIO.evalAsync(1): BIO[String, Int]).redeemCause(_ => 99, identity)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(1))))
+  }
+
+  test("BIO#redeemCause should recover typed error") { implicit s =>
+    val ex = "dummy"
+    val task = (BIO.raiseError(ex): BIO[String, Int]).redeemCause(_ => 99, identity)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(99))))
+  }
+
+  test("BIO#redeemCause should recover unexpected error") { implicit s =>
+    val ex = DummyException("dummy")
+    val task = BIO.evalTotal[Int](if (1 == 1) throw ex else 1).redeemCause(_ => 99, identity)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(99))))
+  }
+
+  test("BIO#redeemCause should protect against user code") { implicit s =>
+    val ex1 = DummyException("one")
+    val ex2 = DummyException("two")
+
+    val task = (BIO.terminate(ex1): BIO[String, Int]).redeemCause(_ => throw ex2, _ => throw ex2)
+
+    val f = task.runToFuture; s.tick()
+    assertEquals(f.value, Some(Failure(ex2)))
+  }
+
+  test("BIO#redeemCauseWith derives flatMap") { implicit s =>
+    check2 { (fa: BIO[String, Int], f: Int => BIO[String, Int]) =>
+      fa.redeemCauseWith(_.fold(BIO.terminate, BIO.raiseError), f) <-> fa.flatMap(f)
+    }
+  }
+
+  test("BIO#redeemCauseWith should mirror source on success") { implicit s =>
+    val task = (UIO.evalAsync(1): BIO[String, Int]).redeemCauseWith(_ => BIO.now(99), BIO.now)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(1))))
+  }
+
+  test("BIO#redeemCauseWith should recover typed error") { implicit s =>
+    val ex = "dummy"
+    val task = (BIO.raiseError(ex): BIO[String, Int]).redeemCauseWith(_ => BIO.now(99), BIO.now)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(99))))
+  }
+
+  test("BIO#redeemCauseWith should recover unexpected error") { implicit s =>
+    val ex = DummyException("dummy")
+    val task = BIO.evalTotal[Int](if (1 == 1) throw ex else 1).redeemCauseWith(_ => BIO.now(99), BIO.now)
+
+    val f = task.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Right(99))))
+  }
+
+  test("BIO#redeemCauseWith should protect against user code") { implicit s =>
+    val ex1 = DummyException("one")
+    val ex2 = DummyException("two")
+
+    val task = (BIO.terminate(ex1): BIO[String, Int]).redeemCauseWith(_ => throw ex2, _ => throw ex2)
+
+    val f = task.runToFuture; s.tick()
+    assertEquals(f.value, Some(Failure(ex2)))
+  }
+}

--- a/core/shared/src/test/scala/monix/bio/TaskTimedSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskTimedSuite.scala
@@ -59,8 +59,8 @@ object TaskTimedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left("Error"))))
   }
 
-  test("not measure tasks with fatal errors") { implicit s =>
-    val bio = BIO.raiseFatalError(DummyException("Fatal")).delayExecution(2.second).timed
+  test("not measure tasks with terminal errors") { implicit s =>
+    val bio = BIO.terminate(DummyException("Fatal")).delayExecution(2.second).timed
     val f = bio.runToFuture
 
     s.tick()
@@ -93,8 +93,8 @@ object TaskTimedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Right(2.second -> Left("Error")))))
   }
 
-  test("not measure tasks with fatal errors followed by `.attempt`") { implicit s =>
-    val bio = BIO.raiseFatalError(DummyException("Fatal")).delayExecution(2.second).attempt.timed
+  test("not measure tasks with terminal errors followed by `.attempt`") { implicit s =>
+    val bio = BIO.terminate(DummyException("Fatal")).delayExecution(2.second).attempt.timed
     val f = bio.runToFuture
 
     s.tick()

--- a/core/shared/src/test/scala/monix/bio/TaskToStringSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskToStringSuite.scala
@@ -37,9 +37,9 @@ object TaskToStringSuite extends SimpleTestSuite {
     assertContains(ref, "BIO.Error")
   }
 
-  test("BIO.FatalError") {
-    val ref = BIO.raiseFatalError(DummyException("dummy"))
-    assertContains(ref, "BIO.FatalError")
+  test("BIO.Termination") {
+    val ref = BIO.terminate(DummyException("dummy"))
+    assertContains(ref, "BIO.Termination")
   }
 
   test("BIO.Eval") {


### PR DESCRIPTION
Fixes #28, related to #40

I'm trying `BIO.terminate`, I also noticed that izumi uses the same name in their bifunctor hierarchy