### PR TITLE
Updated all gatherX and wanderX methods to be parSequenceX and parTra…

### DIFF
--- a/benchmarks/src/main/scala/monix/benchmarks/IOSequenceBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/benchmarks/IOSequenceBenchmark.scala
@@ -116,24 +116,24 @@ class IOSequenceBenchmark {
 
 
   @Benchmark
-  def monixBioGather(): Long = {
+  def monixBioParSequence(): Long = {
     val tasks = (0 until count).map(_ => BIO.eval(1)).toList
-    val result = BIO.gather(tasks).map(_.sum.toLong)
+    val result = BIO.parSequence(tasks).map(_.sum.toLong)
     result.runSyncUnsafe()
   }
 
 
   @Benchmark
-  def monixBioGatherUnordered(): Long = {
+  def monixBioParSequenceUnordered(): Long = {
     val tasks = (0 until count).map(_ => BIO.eval(1)).toList
-    val result = BIO.gatherUnordered(tasks).map(_.sum.toLong)
+    val result = BIO.parSequenceUnordered(tasks).map(_.sum.toLong)
     result.runSyncUnsafe()
   }
 
   @Benchmark
-  def monixBioGatherN(): Long = {
+  def monixBioParSequenceN(): Long = {
     val tasks = (0 until count).map(_ => BIO.eval(1)).toList
-    val result = BIO.gatherN(parallelism)(tasks).map(_.sum.toLong)
+    val result = BIO.parSequenceN(parallelism)(tasks).map(_.sum.toLong)
     result.runSyncUnsafe()
   }
 

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -1615,7 +1615,7 @@ sealed abstract class BIO[+E, +A] extends Serializable {
     * given `thunk` immediately (on the current thread and call stack).
     *
     * By calling `executeOn(io)`, we are ensuring that the used
-    * `Scheduler` (injected in [[BIO.cancelable0[A](register* async tasks]])
+    * `Scheduler` (injected in [[BIO.cancelable0[E, A](register* async tasks]])
     * will be `io`, a `Scheduler` that we intend to use for blocking
     * I/O actions. And we are also forcing an asynchronous boundary
     * right before execution, by passing the `forceAsync` parameter as

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -1615,7 +1615,7 @@ sealed abstract class BIO[+E, +A] extends Serializable {
     * given `thunk` immediately (on the current thread and call stack).
     *
     * By calling `executeOn(io)`, we are ensuring that the used
-    * `Scheduler` (injected in [[BIO.cancelable0[E, A](register* async tasks]])
+    * `Scheduler` (injected in [[BIO.cancelable0]])
     * will be `io`, a `Scheduler` that we intend to use for blocking
     * I/O actions. And we are also forcing an asynchronous boundary
     * right before execution, by passing the `forceAsync` parameter as

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -1327,7 +1327,7 @@ sealed abstract class BIO[+E, +A] extends Serializable {
     * If an exception is raised, then `bracket` will re-raise the exception
     * ''after'' performing the `release`. If the resulting task gets cancelled,
     * then `bracket` will still perform the `release`, but the yielded task
-    * will be non-terminating (equivalent with [[Task.never]]).
+    * will be non-terminating (equivalent with [[BIO.never]]).
     *
     * Example:
     *
@@ -1622,11 +1622,11 @@ sealed abstract class BIO[+E, +A] extends Serializable {
     *   readFile("path/to/file").executeOn(io, forceAsync = true)
     * }}}
     *
-    * In this example we are using [[Task.eval]], which executes the
+    * In this example we are using [[BIO.eval]], which executes the
     * given `thunk` immediately (on the current thread and call stack).
     *
     * By calling `executeOn(io)`, we are ensuring that the used
-    * `Scheduler` (injected in [[Task.cancelable0[A](register* async tasks]])
+    * `Scheduler` (injected in [[BIO.cancelable0[A](register* async tasks]])
     * will be `io`, a `Scheduler` that we intend to use for blocking
     * I/O actions. And we are also forcing an asynchronous boundary
     * right before execution, by passing the `forceAsync` parameter as
@@ -2659,7 +2659,7 @@ sealed abstract class BIO[+E, +A] extends Serializable {
   *         parallelism being guaranteed when multi-threading is available!
   *
   *         All specified tasks get evaluated in parallel, regardless of their
-  *         execution model ([[Task.eval]] vs [[Task.evalAsync]] doesn't matter).
+  *         execution model ([[BIO.eval]] vs [[BIO.evalAsync]] doesn't matter).
   *         Also the implementation tries to be smart about detecting forked
   *         tasks so it can eliminate extraneous forks for the very obvious
   *         cases.
@@ -3397,7 +3397,7 @@ object BIO extends TaskInstancesLevel0 {
     * [[https://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially-Applied Type technique]].
     *
     * Calling `create` with a callback that returns `Unit` is
-    * equivalent with [[Task.async0]]:
+    * equivalent with [[BIO.async0]]:
     *
     * `Task.async0(f) <-> Task.create(f)`
     *
@@ -3444,7 +3444,7 @@ object BIO extends TaskInstancesLevel0 {
     *
     * Passed function can also return `Task[Unit]` as a task that
     * describes a cancelation action, thus for an `f` that can be
-    * passed to [[Task.cancelable0]], and this equivalence holds:
+    * passed to [[BIO.cancelable0]], and this equivalence holds:
     *
     * `Task.cancelable(f) <-> Task.create(f)`
     *
@@ -4950,7 +4950,7 @@ private[bio] abstract class TaskTimers extends TaskClocks {
     }
 }
 
-private[bio] abstract class TaskClocks {
+private[bio] abstract class TaskClocks extends TaskDeprecated.`BIO.Companion` {
 
   /**
     * Default, pure, globally visible `cats.effect.Clock`

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -17,22 +17,11 @@
 
 package monix.bio
 
-import cats.effect.{
-  CancelToken,
-  Clock,
-  Concurrent,
-  ConcurrentEffect,
-  ContextShift,
-  Effect,
-  ExitCase,
-  IO,
-  Timer,
-  Fiber => _
-}
-import cats.{~>, CommutativeApplicative, Monoid, Parallel, Semigroup}
+import cats.effect.{CancelToken, Clock, Concurrent, ConcurrentEffect, ContextShift, Effect, ExitCase, IO, Timer, Fiber => _}
+import cats.{CommutativeApplicative, Monoid, Parallel, Semigroup, ~>}
 import monix.bio.compat.internal.newBuilder
 import monix.bio.instances._
-import monix.bio.internal._
+import monix.bio.internal.{TaskDeprecated, _}
 import monix.catnap.FutureLift
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import monix.execution.annotations.{UnsafeBecauseBlocking, UnsafeBecauseImpure}
@@ -4950,7 +4939,7 @@ private[bio] abstract class TaskTimers extends TaskClocks {
     }
 }
 
-private[bio] abstract class TaskClocks extends TaskDeprecated.`BIO.Companion` {
+private[bio] abstract class TaskClocks extends BIODeprecated.Companion {
 
   /**
     * Default, pure, globally visible `cats.effect.Clock`

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -3772,7 +3772,7 @@ object BIO extends TaskInstancesLevel0 {
     *   val numbers = List(1, 2, 3, 4)
     *
     *   // Yields 2, 4, 6, 8 after around 6 seconds
-    *   BIO.parTraversN(2)(numbers)(n => BIO(n + n).delayExecution(n.second))
+    *   BIO.parTraverseN(2)(numbers)(n => BIO(n + n).delayExecution(n.second))
     * }}}
     *
     * $parallelismAdvice

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -21,7 +21,7 @@ import cats.effect.{CancelToken, Clock, Concurrent, ConcurrentEffect, ContextShi
 import cats.{CommutativeApplicative, Monoid, Parallel, Semigroup, ~>}
 import monix.bio.compat.internal.newBuilder
 import monix.bio.instances._
-import monix.bio.internal.{TaskDeprecated, _}
+import monix.bio.internal._
 import monix.catnap.FutureLift
 import monix.execution.ExecutionModel.AlwaysAsyncExecution
 import monix.execution.annotations.{UnsafeBecauseBlocking, UnsafeBecauseImpure}

--- a/core/shared/src/main/scala/monix/bio/BIO.scala
+++ b/core/shared/src/main/scala/monix/bio/BIO.scala
@@ -17,8 +17,19 @@
 
 package monix.bio
 
-import cats.effect.{CancelToken, Clock, Concurrent, ConcurrentEffect, ContextShift, Effect, ExitCase, IO, Timer, Fiber => _}
-import cats.{CommutativeApplicative, Monoid, Parallel, Semigroup, ~>}
+import cats.effect.{
+  CancelToken,
+  Clock,
+  Concurrent,
+  ConcurrentEffect,
+  ContextShift,
+  Effect,
+  ExitCase,
+  IO,
+  Timer,
+  Fiber => _
+}
+import cats.{~>, CommutativeApplicative, Monoid, Parallel, Semigroup}
 import monix.bio.compat.internal.newBuilder
 import monix.bio.instances._
 import monix.bio.internal._
@@ -3684,7 +3695,9 @@ object BIO extends TaskInstancesLevel0 {
     *
     * @see [[parSequenceN]] for a version that limits parallelism.
     */
-  def parSequence[E, A, M[X] <: Iterable[X]](in: M[BIO[E, A]])(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] =
+  def parSequence[E, A, M[X] <: Iterable[X]](
+    in: M[BIO[E, A]]
+  )(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] =
     TaskParSequence[E, A, M](in, () => newBuilder(bf, in))
 
   /** Given a `Iterable[A]` and a function `A => BIO[E, B]`,
@@ -3745,7 +3758,6 @@ object BIO extends TaskInstancesLevel0 {
     */
   def parSequenceN[E, A](parallelism: Int)(in: Iterable[BIO[E, A]]): BIO[E, List[A]] =
     TaskParSequenceN[E, A](parallelism, in)
-
 
   /** Applies the provided function in a non-deterministic way to each element
     * of the input collection. The result will be signalled once all tasks

--- a/core/shared/src/main/scala/monix/bio/Task.scala
+++ b/core/shared/src/main/scala/monix/bio/Task.scala
@@ -20,7 +20,7 @@ package monix.bio
 import cats.effect.{CancelToken, ConcurrentEffect, Effect}
 import cats.~>
 import monix.bio.BIO.AsyncBuilder
-import monix.bio.internal.{TaskCreate, TaskFromFuture}
+import monix.bio.internal.{TaskCreate, TaskDeprecated, TaskFromFuture}
 import monix.catnap.FutureLift
 import monix.execution.compat.BuildFrom
 import monix.execution.{CancelablePromise, Scheduler}
@@ -30,7 +30,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-object Task {
+object Task extends TaskDeprecated.Companion {
 
   /**
     * @see See [[monix.bio.BIO.apply]]

--- a/core/shared/src/main/scala/monix/bio/Task.scala
+++ b/core/shared/src/main/scala/monix/bio/Task.scala
@@ -287,34 +287,34 @@ object Task {
     BIO.traverse(in)(f)
 
   /**
-    * @see See [[monix.bio.BIO.gather]]
+    * @see See [[monix.bio.BIO.parSequence]]
     */
-  def gather[A, M[X] <: Iterable[X]](in: M[Task[A]])(implicit bf: BuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
-    BIO.gather(in)
+  def parSequence[A, M[X] <: Iterable[X]](in: M[Task[A]])(implicit bf: BuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
+    BIO.parSequence(in)
 
   /**
-    * @see See [[monix.bio.BIO.gatherN]]
+    * @see See [[monix.bio.BIO.parSequenceN]]
     */
-  def gatherN[A](parallelism: Int)(in: Iterable[Task[A]]): Task[List[A]] =
-    BIO.gatherN(parallelism)(in)
+  def parSequenceN[A](parallelism: Int)(in: Iterable[Task[A]]): Task[List[A]] =
+    BIO.parSequenceN(parallelism)(in)
 
   /**
-    * @see [[monix.bio.BIO.wander]]
+    * @see [[monix.bio.BIO.parTraverse]]
     */
-  def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] =
-    BIO.wander(in)(f)
+  def parTraverse[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] =
+    BIO.parTraverse(in)(f)
 
   /**
-    * @see See [[monix.bio.BIO.gatherUnordered]]
+    * @see See [[monix.bio.BIO.parSequenceUnordered]]
     */
-  def gatherUnordered[A](in: Iterable[Task[A]]): Task[List[A]] =
-    BIO.gatherUnordered(in)
+  def parSequenceUnordered[A](in: Iterable[Task[A]]): Task[List[A]] =
+    BIO.parSequenceUnordered(in)
 
   /**
-    * @see [[monix.bio.BIO.wanderUnordered]]
+    * @see [[monix.bio.BIO.parTraverseUnordered]]
     */
-  def wanderUnordered[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
-    BIO.wanderUnordered(in)(f)
+  def parTraverseUnordered[A, B](in: Iterable[A])(f: A => Task[B]): Task[List[B]] =
+    BIO.parTraverseUnordered(in)(f)
 
   /**
     * @see See [[monix.bio.BIO.mapBoth]]

--- a/core/shared/src/main/scala/monix/bio/Task.scala
+++ b/core/shared/src/main/scala/monix/bio/Task.scala
@@ -295,7 +295,9 @@ object Task extends TaskDeprecated.Companion {
   /**
     * @see [[monix.bio.BIO.parTraverse]]
     */
-  def parTraverse[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] =
+  def parTraverse[A, B, M[X] <: Iterable[X]](
+    in: M[A]
+  )(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] =
     BIO.parTraverse(in)(f)
 
   /**

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -201,7 +201,9 @@ object UIO extends UIODeprecated.Companion {
   /**
     * @see [[monix.bio.BIO.parTraverse]]
     */
-  def parTraverse[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] =
+  def parTraverse[A, B, M[X] <: Iterable[X]](
+    in: M[A]
+  )(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] =
     BIO.parTraverse(in)(f)
 
   /**

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -193,34 +193,34 @@ object UIO {
     TaskSequence.traverse(in, f)(bf)
 
   /**
-    * @see See [[monix.bio.BIO.gather]]
+    * @see See [[monix.bio.BIO.parSequence]]
     */
-  def gather[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] =
-    TaskGather[Nothing, A, M](in, () => newBuilder(bf, in))
+  def parSequence[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] =
+    TaskParSequence[Nothing, A, M](in, () => newBuilder(bf, in))
 
   /**
-    * @see See [[monix.bio.BIO.gatherN]]
+    * @see See [[monix.bio.BIO.parSequenceN]]
     */
-  def gatherN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] =
-    TaskGatherN[Nothing, A](parallelism, in)
+  def parSequenceN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] =
+    TaskParSequenceN[Nothing, A](parallelism, in)
 
   /**
-    * @see [[monix.bio.BIO.wander]]
+    * @see [[monix.bio.BIO.parTraverse]]
     */
-  def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] =
-    BIO.wander(in)(f)
+  def parTraverse[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] =
+    BIO.parTraverse(in)(f)
 
   /**
-    * @see See [[monix.bio.BIO.gatherUnordered]]
+    * @see See [[monix.bio.BIO.parSequenceUnordered]]
     */
-  def gatherUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] =
-    TaskGatherUnordered[Nothing, A](in)
+  def parSequenceUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] =
+    TaskParSequenceUnordered[Nothing, A](in)
 
   /**
-    * @see [[monix.bio.BIO.wanderUnordered]]
+    * @see [[monix.bio.BIO.parTraverseUnordered]]
     */
-  def wanderUnordered[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
-    BIO.wanderUnordered(in)(f)
+  def parTraverseUnordered[A, B](in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] =
+    BIO.parTraverseUnordered(in)(f)
 
   /**
     * @see See [[monix.bio.BIO.mapBoth]]

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -18,14 +18,14 @@
 package monix.bio
 
 import monix.bio.compat.internal.newBuilder
-import monix.bio.internal._
+import monix.bio.internal.{TaskDeprecated, _}
 import monix.execution.compat.BuildFrom
 import monix.execution.{CancelablePromise, Scheduler}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
-object UIO extends TaskDeprecated.`UIO.Companion` {
+object UIO extends UIODeprecated.Companion {
 
   /**
     * @see See [[monix.bio.BIO.apply]]

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -18,7 +18,7 @@
 package monix.bio
 
 import monix.bio.compat.internal.newBuilder
-import monix.bio.internal.{TaskDeprecated, _}
+import monix.bio.internal._
 import monix.execution.compat.BuildFrom
 import monix.execution.{CancelablePromise, Scheduler}
 

--- a/core/shared/src/main/scala/monix/bio/UIO.scala
+++ b/core/shared/src/main/scala/monix/bio/UIO.scala
@@ -25,7 +25,7 @@ import monix.execution.{CancelablePromise, Scheduler}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
-object UIO {
+object UIO extends TaskDeprecated.`UIO.Companion` {
 
   /**
     * @see See [[monix.bio.BIO.apply]]

--- a/core/shared/src/main/scala/monix/bio/internal/BIODeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/BIODeprecated.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.bio.internal
 
 import monix.bio.BIO
@@ -12,7 +29,9 @@ private[bio] object BIODeprecated {
 
     /** DEPRECATED — renamed to [[BIO.parSequence]]. */
     @deprecated("Use parSequence", "0.1.0")
-    def gather[E, A, M[X] <: Iterable[X]](in: M[BIO[E, A]])(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] = {
+    def gather[E, A, M[X] <: Iterable[X]](
+      in: M[BIO[E, A]]
+    )(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] = {
       // $COVERAGE-OFF$
       BIO.parSequence(in)
       // $COVERAGE-ON$
@@ -36,7 +55,9 @@ private[bio] object BIODeprecated {
 
     /** DEPRECATED — renamed to [[BIO.parTraverse]] */
     @deprecated("Use parTraverse", "0.1.0")
-    def wander[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B])(implicit bf: BuildFrom[M[A], B, M[B]]): BIO[E, M[B]] = {
+    def wander[E, A, B, M[X] <: Iterable[X]](
+      in: M[A]
+    )(f: A => BIO[E, B])(implicit bf: BuildFrom[M[A], B, M[B]]): BIO[E, M[B]] = {
       // $COVERAGE-OFF$
       BIO.parTraverse(in)(f)
       // $COVERAGE-ON$

--- a/core/shared/src/main/scala/monix/bio/internal/BIODeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/BIODeprecated.scala
@@ -1,0 +1,61 @@
+package monix.bio.internal
+
+import monix.bio.BIO
+import monix.execution.compat.BuildFrom
+
+private[bio] object BIODeprecated {
+
+  /**
+    * Extension methods describing deprecated `BIO` operations.
+    */
+  private[bio] abstract class Companion {
+
+    /** DEPRECATED — renamed to [[BIO.parSequence]]. */
+    @deprecated("Use parSequence", "0.1.0")
+    def gather[E, A, M[X] <: Iterable[X]](in: M[BIO[E, A]])(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequence(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parSequenceN]] */
+    @deprecated("Use parSequenceN", "0.1.0")
+    def gatherN[E, A](parallelism: Int)(in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequenceN(parallelism)(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parSequenceUnordered]] */
+    @deprecated("Use parSequenceUnordered", "0.1.0")
+    def gatherUnordered[E, A](in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequenceUnordered(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverse]] */
+    @deprecated("Use parTraverse", "0.1.0")
+    def wander[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B])(implicit bf: BuildFrom[M[A], B, M[B]]): BIO[E, M[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverse(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseN]] */
+    @deprecated("Use parTraverseN", "0.1.0")
+    def wanderN[E, A, B](parallelism: Int)(in: Iterable[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseN(parallelism)(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
+    @deprecated("Use parTraverseUnordered", "3.2.0")
+    def wanderUnordered[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseUnordered(in)(f)
+      // $COVERAGE-ON$
+    }
+  }
+}

--- a/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
@@ -1,6 +1,6 @@
-package monix.bio
-package internal
+package monix.bio.internal
 
+import monix.bio.{BIO, Task}
 import monix.execution.compat.BuildFrom
 
 private[bio] object TaskDeprecated {
@@ -46,7 +46,7 @@ private[bio] object TaskDeprecated {
     @deprecated("Use parTraverseN", "0.1.0")
     def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => Task[B]): Task[List[B]] = {
       // $COVERAGE-OFF$
-      BIO.parTraverseN(parallelism)(in)(f)
+      Task.parTraverseN(parallelism)(in)(f)
       // $COVERAGE-ON$
     }
 
@@ -59,110 +59,6 @@ private[bio] object TaskDeprecated {
     }
   }
 
-  /**
-    * Extension methods describing deprecated `UIO` operations.
-    */
-  private[bio] abstract class `UIO.Companion` {
-    
-    /** DEPRECATED — renamed to [[UIO.parSequence]]. */
-    @deprecated("Use parSequence", "0.1.0")
-    def gather[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] = {
-      // $COVERAGE-OFF$
-      UIO.parSequence(in)
-      // $COVERAGE-ON$
-    }
 
-    /** DEPRECATED — renamed to [[UIO.parSequenceN]] */
-    @deprecated("Use parSequenceN", "0.1.0")
-    def gatherN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] = {
-      // $COVERAGE-OFF$
-      UIO.parSequenceN(parallelism)(in)
-      // $COVERAGE-ON$
-    }
 
-    /** DEPRECATED — renamed to [[UIO.parSequenceUnordered]] */
-    @deprecated("Use parSequenceUnordered", "0.1.0")
-    def gatherUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] = {
-      // $COVERAGE-OFF$
-      UIO.parSequenceUnordered(in)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[UIO.parTraverse]] */
-    @deprecated("Use parTraverse", "0.1.0")
-    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] = {
-      // $COVERAGE-OFF$
-      UIO.parTraverse(in)(f)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[UIO.parTraverseN]] */
-    @deprecated("Use parTraverseN", "0.1.0")
-    def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] = {
-      // $COVERAGE-OFF$
-      BIO.parTraverseN(parallelism)(in)(f)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
-    @deprecated("Use parTraverseUnordered", "3.2.0")
-    def wanderUnordered[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B]): UIO[List[B]] = {
-      // $COVERAGE-OFF$
-      UIO.parTraverseUnordered(in)(f)
-      // $COVERAGE-ON$
-    }
-  }
-
-  /**
-    * Extension methods describing deprecated `BIO` operations.
-    */
-  private[bio] abstract class `BIO.Companion` {
-    /** DEPRECATED — renamed to [[BIO.parSequence]]. */
-    @deprecated("Use parSequence", "0.1.0")
-    def gather[E, A, M[X] <: Iterable[X]](in: M[BIO[E, A]])(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] = {
-      // $COVERAGE-OFF$
-      BIO.parSequence(in)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parSequenceN]] */
-    @deprecated("Use parSequenceN", "0.1.0")
-    def gatherN[E, A](parallelism: Int)(in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
-      // $COVERAGE-OFF$
-      BIO.parSequenceN(parallelism)(in)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parSequenceUnordered]] */
-    @deprecated("Use parSequenceUnordered", "0.1.0")
-    def gatherUnordered[E, A](in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
-      // $COVERAGE-OFF$
-      BIO.parSequenceUnordered(in)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parTraverse]] */
-    @deprecated("Use parTraverse", "0.1.0")
-    def wander[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B])(implicit bf: BuildFrom[M[A], B, M[B]]): BIO[E, M[B]] = {
-      // $COVERAGE-OFF$
-      BIO.parTraverse(in)(f)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parTraverseN]] */
-    @deprecated("Use parTraverseN", "0.1.0")
-    def wanderN[E, A, B](parallelism: Int)(in: Iterable[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
-      // $COVERAGE-OFF$
-      BIO.parTraverseN(parallelism)(in)(f)
-      // $COVERAGE-ON$
-    }
-
-    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
-    @deprecated("Use parTraverseUnordered", "3.2.0")
-    def wanderUnordered[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
-      // $COVERAGE-OFF$
-      BIO.parTraverseUnordered(in)(f)
-      // $COVERAGE-ON$
-    }
-  }
 }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
@@ -1,6 +1,23 @@
+/*
+ * Copyright (c) 2019-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.bio.internal
 
-import monix.bio.{BIO, Task}
+import monix.bio.Task
 import monix.execution.compat.BuildFrom
 
 private[bio] object TaskDeprecated {
@@ -36,7 +53,9 @@ private[bio] object TaskDeprecated {
 
     /** DEPRECATED — renamed to [[Task.parTraverse]] */
     @deprecated("Use parTraverse", "0.1.0")
-    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] = {
+    def wander[A, B, M[X] <: Iterable[X]](
+      in: M[A]
+    )(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] = {
       // $COVERAGE-OFF$
       Task.parTraverse(in)(f)
       // $COVERAGE-ON$
@@ -58,7 +77,5 @@ private[bio] object TaskDeprecated {
       // $COVERAGE-ON$
     }
   }
-
-
 
 }

--- a/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskDeprecated.scala
@@ -1,0 +1,168 @@
+package monix.bio
+package internal
+
+import monix.execution.compat.BuildFrom
+
+private[bio] object TaskDeprecated {
+
+  /**
+    * Extension methods describing deprecated `Task` operations.
+    */
+  private[bio] abstract class Companion {
+
+    /** DEPRECATED — renamed to [[Task.parSequence]]. */
+    @deprecated("Use parSequence", "0.1.0")
+    def gather[A, M[X] <: Iterable[X]](in: M[Task[A]])(implicit bf: BuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] = {
+      // $COVERAGE-OFF$
+      Task.parSequence(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[Task.parSequenceN]] */
+    @deprecated("Use parSequenceN", "0.1.0")
+    def gatherN[A](parallelism: Int)(in: Iterable[Task[A]]): Task[List[A]] = {
+      // $COVERAGE-OFF$
+      Task.parSequenceN(parallelism)(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[Task.parSequenceUnordered]] */
+    @deprecated("Use parSequenceUnordered", "0.1.0")
+    def gatherUnordered[A](in: Iterable[Task[A]]): Task[List[A]] = {
+      // $COVERAGE-OFF$
+      Task.parSequenceUnordered(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[Task.parTraverse]] */
+    @deprecated("Use parTraverse", "0.1.0")
+    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B])(implicit bf: BuildFrom[M[A], B, M[B]]): Task[M[B]] = {
+      // $COVERAGE-OFF$
+      Task.parTraverse(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[Task.parTraverseN]] */
+    @deprecated("Use parTraverseN", "0.1.0")
+    def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => Task[B]): Task[List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseN(parallelism)(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
+    @deprecated("Use parTraverseUnordered", "3.2.0")
+    def wanderUnordered[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => Task[B]): Task[List[B]] = {
+      // $COVERAGE-OFF$
+      Task.parTraverseUnordered(in)(f)
+      // $COVERAGE-ON$
+    }
+  }
+
+  /**
+    * Extension methods describing deprecated `UIO` operations.
+    */
+  private[bio] abstract class `UIO.Companion` {
+    
+    /** DEPRECATED — renamed to [[UIO.parSequence]]. */
+    @deprecated("Use parSequence", "0.1.0")
+    def gather[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequence(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parSequenceN]] */
+    @deprecated("Use parSequenceN", "0.1.0")
+    def gatherN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequenceN(parallelism)(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parSequenceUnordered]] */
+    @deprecated("Use parSequenceUnordered", "0.1.0")
+    def gatherUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequenceUnordered(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parTraverse]] */
+    @deprecated("Use parTraverse", "0.1.0")
+    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] = {
+      // $COVERAGE-OFF$
+      UIO.parTraverse(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parTraverseN]] */
+    @deprecated("Use parTraverseN", "0.1.0")
+    def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseN(parallelism)(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
+    @deprecated("Use parTraverseUnordered", "3.2.0")
+    def wanderUnordered[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B]): UIO[List[B]] = {
+      // $COVERAGE-OFF$
+      UIO.parTraverseUnordered(in)(f)
+      // $COVERAGE-ON$
+    }
+  }
+
+  /**
+    * Extension methods describing deprecated `BIO` operations.
+    */
+  private[bio] abstract class `BIO.Companion` {
+    /** DEPRECATED — renamed to [[BIO.parSequence]]. */
+    @deprecated("Use parSequence", "0.1.0")
+    def gather[E, A, M[X] <: Iterable[X]](in: M[BIO[E, A]])(implicit bf: BuildFrom[M[BIO[E, A]], A, M[A]]): BIO[E, M[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequence(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parSequenceN]] */
+    @deprecated("Use parSequenceN", "0.1.0")
+    def gatherN[E, A](parallelism: Int)(in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequenceN(parallelism)(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parSequenceUnordered]] */
+    @deprecated("Use parSequenceUnordered", "0.1.0")
+    def gatherUnordered[E, A](in: Iterable[BIO[E, A]]): BIO[E, List[A]] = {
+      // $COVERAGE-OFF$
+      BIO.parSequenceUnordered(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverse]] */
+    @deprecated("Use parTraverse", "0.1.0")
+    def wander[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B])(implicit bf: BuildFrom[M[A], B, M[B]]): BIO[E, M[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverse(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseN]] */
+    @deprecated("Use parTraverseN", "0.1.0")
+    def wanderN[E, A, B](parallelism: Int)(in: Iterable[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseN(parallelism)(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
+    @deprecated("Use parTraverseUnordered", "3.2.0")
+    def wanderUnordered[E, A, B, M[X] <: Iterable[X]](in: M[A])(f: A => BIO[E, B]): BIO[E, List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseUnordered(in)(f)
+      // $COVERAGE-ON$
+    }
+  }
+}

--- a/core/shared/src/main/scala/monix/bio/internal/TaskParSequence.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskParSequence.scala
@@ -27,10 +27,10 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
-private[bio] object TaskGather {
+private[bio] object TaskParSequence {
 
   /**
-    * Implementation for `Task.gather`
+    * Implementation for `Task.parSequence`
     */
   def apply[E, A, M[X] <: Iterable[X]](
     in: Iterable[BIO[E, A]],

--- a/core/shared/src/main/scala/monix/bio/internal/TaskParSequenceN.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskParSequenceN.scala
@@ -24,7 +24,7 @@ import monix.catnap.ConcurrentQueue
 import monix.execution.exceptions.UncaughtErrorException
 import monix.execution.{BufferCapacity, ChannelType}
 
-private[bio] object TaskGatherN {
+private[bio] object TaskParSequenceN {
 
   def apply[E, A](
     parallelism: Int,
@@ -44,7 +44,7 @@ private[bio] object TaskGatherN {
           .hideErrors
         pairs <- BIO.traverse(in.toList)(task => Deferred[Task, A].map(p => (p, task)).hideErrors)
         _     <- queue.offerMany(pairs).hideErrors
-        workers = UIO.gather(List.fill(parallelism.min(itemSize)) {
+        workers = UIO.parSequence(List.fill(parallelism.min(itemSize)) {
           queue.poll.hideErrors.flatMap {
             case (p, task) =>
               task.redeemCauseWith(

--- a/core/shared/src/main/scala/monix/bio/internal/TaskParSequenceUnordered.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/TaskParSequenceUnordered.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
-private[bio] object TaskGatherUnordered {
+private[bio] object TaskParSequenceUnordered {
 
   /**
     * Implementation for `Task.gatherUnordered`

--- a/core/shared/src/main/scala/monix/bio/internal/UIODeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/UIODeprecated.scala
@@ -1,0 +1,61 @@
+package monix.bio.internal
+
+import monix.bio.{BIO, UIO}
+import monix.execution.compat.BuildFrom
+
+private[bio] object UIODeprecated {
+
+  /**
+    * Extension methods describing deprecated `UIO` operations.
+    */
+  private[bio] abstract class Companion {
+
+    /** DEPRECATED — renamed to [[UIO.parSequence]]. */
+    @deprecated("Use parSequence", "0.1.0")
+    def gather[A, M[X] <: Iterable[X]](in: M[UIO[A]])(implicit bf: BuildFrom[M[UIO[A]], A, M[A]]): UIO[M[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequence(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parSequenceN]] */
+    @deprecated("Use parSequenceN", "0.1.0")
+    def gatherN[A](parallelism: Int)(in: Iterable[UIO[A]]): UIO[List[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequenceN(parallelism)(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parSequenceUnordered]] */
+    @deprecated("Use parSequenceUnordered", "0.1.0")
+    def gatherUnordered[A](in: Iterable[UIO[A]]): UIO[List[A]] = {
+      // $COVERAGE-OFF$
+      UIO.parSequenceUnordered(in)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parTraverse]] */
+    @deprecated("Use parTraverse", "0.1.0")
+    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] = {
+      // $COVERAGE-OFF$
+      UIO.parTraverse(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[UIO.parTraverseN]] */
+    @deprecated("Use parTraverseN", "0.1.0")
+    def wanderN[A, B](parallelism: Int)(in: Iterable[A])(f: A => UIO[B]): UIO[List[B]] = {
+      // $COVERAGE-OFF$
+      BIO.parTraverseN(parallelism)(in)(f)
+      // $COVERAGE-ON$
+    }
+
+    /** DEPRECATED — renamed to [[BIO.parTraverseUnordered]] */
+    @deprecated("Use parTraverseUnordered", "3.2.0")
+    def wanderUnordered[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B]): UIO[List[B]] = {
+      // $COVERAGE-OFF$
+      UIO.parTraverseUnordered(in)(f)
+      // $COVERAGE-ON$
+    }
+  }
+}

--- a/core/shared/src/main/scala/monix/bio/internal/UIODeprecated.scala
+++ b/core/shared/src/main/scala/monix/bio/internal/UIODeprecated.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.bio.internal
 
 import monix.bio.{BIO, UIO}
@@ -36,7 +53,9 @@ private[bio] object UIODeprecated {
 
     /** DEPRECATED — renamed to [[UIO.parTraverse]] */
     @deprecated("Use parTraverse", "0.1.0")
-    def wander[A, B, M[X] <: Iterable[X]](in: M[A])(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] = {
+    def wander[A, B, M[X] <: Iterable[X]](
+      in: M[A]
+    )(f: A => UIO[B])(implicit bf: BuildFrom[M[A], B, M[B]]): UIO[M[B]] = {
       // $COVERAGE-OFF$
       UIO.parTraverse(in)(f)
       // $COVERAGE-ON$

--- a/core/shared/src/test/scala/monix/bio/TaskParSequenceNSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskParSequenceNSuite.scala
@@ -18,97 +18,133 @@
 package monix.bio
 
 import cats.effect.ExitCase
+import monix.execution.atomic.AtomicInt
 import monix.execution.exceptions.{DummyException, UncaughtErrorException}
 import monix.execution.internal.Platform
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-object TaskGatherSuite extends BaseTestSuite {
-  test("BIO.gather should execute in parallel for async tasks") { implicit s =>
+object TaskParSequenceNSuite extends BaseTestSuite {
+
+  test("BIO.parSequenceN should execute in parallel bounded by parallelism") { implicit s =>
+    val num = AtomicInt(0)
+    val task = UIO.evalAsync(num.increment()) >> BIO.sleep(2.seconds)
+    val seq = List.fill(100)(task)
+
+    BIO.parSequenceN(5)(seq).runToFuture
+
+    s.tick()
+    assertEquals(num.get(), 5)
+    s.tick(2.seconds)
+    assertEquals(num.get(), 10)
+    s.tick(4.seconds)
+    assertEquals(num.get(), 20)
+    s.tick(34.seconds)
+    assertEquals(num.get(), 100)
+  }
+
+  test("BIO.parSequenceN should return result in order") { implicit s =>
+    val task = 1.until(10).toList.map(UIO.eval(_))
+    val res = BIO.parSequenceN(2)(task).runToFuture
+
+    s.tick()
+    assertEquals(res.value, Some(Success(List(1, 2, 3, 4, 5, 6, 7, 8, 9))))
+  }
+
+  test("BIO.parSequenceN should return empty list") { implicit s =>
+    val res = BIO.parSequenceN(2)(List.empty).runToFuture
+
+    s.tick()
+    assertEquals(res.value, Some(Success(List.empty)))
+  }
+
+  test("BIO.parSequenceN should handle single item") { implicit s =>
+    val task = List(Task.eval(1))
+    val res = BIO.parSequenceN(2)(task).runToFuture
+
+    s.tick()
+    assertEquals(res.value, Some(Success(List(1))))
+  }
+
+  test("BIO.parSequenceN should handle parallelism bigger than list") { implicit s =>
+    val task = 1.until(5).toList.map(UIO.eval(_))
+    val res = BIO.parSequenceN(10)(task).runToFuture
+
+    s.tick()
+    assertEquals(res.value, Some(Success(List(1, 2, 3, 4))))
+  }
+
+  test("BIO.parSequenceN should onError if one of the tasks terminates in error") { implicit s =>
+    val ex = "dummy"
     val seq = Seq(
-      BIO.evalAsync(1).delayExecution(2.seconds),
+      BIO.evalAsync(3).delayExecution(2.seconds),
       BIO.evalAsync(2).delayExecution(1.second),
-      BIO.evalAsync(3).delayExecution(3.seconds)
+      BIO.raiseError(ex).delayExecution(2.seconds),
+      BIO.evalAsync(3).delayExecution(1.seconds)
     )
-    val f = BIO.gather(seq).runToFuture
+
+    val f = BIO.parSequenceN(2)(seq).attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
     s.tick(2.seconds)
-    assertEquals(f.value, None)
-    s.tick(1.second)
-    assertEquals(f.value, Some(Success(Seq(1, 2, 3))))
-  }
-
-  test("BIO.gather should onError if one of the tasks terminates in error") { implicit s =>
-    val ex = "dummy"
-    val seq = Seq(
-      UIO.evalAsync(3).delayExecution(3.seconds),
-      UIO.evalAsync(2).delayExecution(1.second),
-      BIO.raiseError(ex).delayExecution(2.seconds),
-      UIO.evalAsync(3).delayExecution(1.seconds)
-    )
-
-    val f = BIO.gather(seq).attempt.runToFuture
-
-    s.tick()
     assertEquals(f.value, None)
     s.tick(2.seconds)
     assertEquals(f.value, Some(Success(Left(ex))))
   }
 
-  test("BIO.gather should onTerminate if one of the tasks terminates in a fatal error") { implicit s =>
+  test("BIO.parSequenceN should onTerminate if one of the tasks terminates in a fatal error") { implicit s =>
     val ex = DummyException("dummy")
-    val seq: Seq[BIO[String, Int]] = Seq(
-      UIO.evalAsync(3).delayExecution(3.seconds),
+    val seq = Seq(
+      UIO.evalAsync(3).delayExecution(2.seconds),
       UIO.evalAsync(2).delayExecution(1.second),
       UIO.evalAsync(throw ex).delayExecution(2.seconds),
       UIO.evalAsync(3).delayExecution(1.seconds)
     )
 
-    val f = BIO.gather(seq).attempt.runToFuture
+    val f = BIO.parSequenceN(2)(seq).runToFuture
 
     s.tick()
+    assertEquals(f.value, None)
+    s.tick(2.seconds)
     assertEquals(f.value, None)
     s.tick(2.seconds)
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("BIO.gather should be canceled") { implicit s =>
-    val seq: Seq[BIO[Int, Int]] = Seq(
-      UIO.evalAsync(1).delayExecution(2.seconds),
-      UIO.evalAsync(2).delayExecution(1.second),
-      UIO.evalAsync(3).delayExecution(3.seconds)
+  test("BIO.parSequenceN should be canceled") { implicit s =>
+    val num = AtomicInt(0)
+    val seq = Seq(
+      BIO.unit.delayExecution(3.seconds).doOnCancel(UIO.eval(num.increment())),
+      UIO.evalAsync(num.increment(10))
     )
-    val f = BIO.gather(seq).attempt.runToFuture
+    val f = BIO.parSequenceN(1)(seq).runToFuture
 
-    s.tick()
-    assertEquals(f.value, None)
     s.tick(2.seconds)
-    assertEquals(f.value, None)
-
     f.cancel()
-    s.tick(1.second)
-    assertEquals(f.value, None)
+    assertEquals(num.get(), 1)
+
+    s.tick(1.day)
+    assertEquals(num.get(), 1)
   }
 
-  test("BIO.gather should be stack safe for synchronous tasks") { implicit s =>
+  test("BIO.parSequenceN should be stack safe for synchronous tasks") { implicit s =>
     val count = if (Platform.isJVM) 200000 else 5000
     val tasks = for (_ <- 0 until count) yield Task.now(1)
-    val composite = BIO.gather(tasks).map(_.sum)
+    val composite = BIO.parSequenceN(count)(tasks).map(_.sum)
     val result = composite.runToFuture
     s.tick()
     assertEquals(result.value, Some(Success(count)))
   }
 
-  test("BIO.gather runAsync multiple times") { implicit s =>
+  test("BIO.parSequenceN runAsync multiple times") { implicit s =>
     var effect = 0
     val task1 = UIO.evalAsync { effect += 1; 3 }.memoize
     val task2 = task1 map { x =>
       effect += 1; x + 1
     }
-    val task3 = UIO.gather(List(task2, task2, task2))
+    val task3 = BIO.parSequenceN(2)(List(task2, task2, task2))
 
     val result1 = task3.runToFuture; s.tick()
     assertEquals(result1.value, Some(Success(List(4, 4, 4))))
@@ -119,7 +155,7 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(effect, 1 + 3 + 3)
   }
 
-  test("BIO.gather should log errors if multiple errors happen") { implicit s =>
+  test("BIO.parSequenceN should log errors if multiple errors happen") { implicit s =>
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
 
     val ex = "dummy1"
@@ -145,8 +181,8 @@ object TaskGatherSuite extends BaseTestSuite {
       }
       .uncancelable
 
-    val gather = BIO.gather(Seq(task1, task2))
-    val result = gather.attempt.runToFutureOpt
+    val sequence = BIO.parSequenceN(4)(Seq(task1, task2))
+    val result = sequence.attempt.runToFutureOpt
     s.tick()
 
     assertEquals(result.value, Some(Success(Left(ex))))
@@ -154,7 +190,7 @@ object TaskGatherSuite extends BaseTestSuite {
     assertEquals(errorsThrow, 2)
   }
 
-  test("BIO.gather should log terminal errors if multiple errors happen") { implicit s =>
+  test("BIO.parSequenceN should log terminal errors if multiple errors happen") { implicit s =>
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
 
     val ex = DummyException("dummy1")
@@ -180,8 +216,8 @@ object TaskGatherSuite extends BaseTestSuite {
       }
       .uncancelable
 
-    val gather = BIO.gather(Seq(task1, task2))
-    val result = gather.attempt.runToFutureOpt
+    val sequence = BIO.parSequenceN(4)(Seq(task1, task2))
+    val result = sequence.attempt.runToFutureOpt
     s.tick()
 
     assertEquals(result.value, Some(Failure(ex)))

--- a/core/shared/src/test/scala/monix/bio/TaskParTraverseNSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskParTraverseNSuite.scala
@@ -29,10 +29,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN allows fully sequential execution") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
       BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -47,10 +47,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN allows fully concurrent execution") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
       BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -65,10 +65,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN allows partially concurrent execution") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -87,11 +87,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when fully sequential execution fails in a typed way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
       if (num == 10) BIO.fromEither("dummy error".asLeft[Int]).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -106,11 +106,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when fully sequential execution fails in a terminal way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 1)(numbers) { num =>
       if (num == 10) BIO.terminate(DummyException("dummy exception")).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -125,11 +125,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when fully concurrent execution fails in a typed way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
       if (num == 10) BIO.fromEither("dummy error".asLeft[Int]).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -144,11 +144,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when fully concurrent execution fails in a terminal way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
       if (num == 10) BIO.terminate(DummyException("dummy exception")).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -163,11 +163,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when partially concurrent execution fails in a typed way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       if (num == 10) BIO.fromEither("dummy error".asLeft[Int]).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -184,11 +184,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns an error when partially concurrent execution fails in a terminal way") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       if (num == 10) BIO.terminate(DummyException("dummy exception")).delayExecution(num.seconds)
       else BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -205,11 +205,11 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN returns a terminal error when an exception is thrown") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 5)(numbers) { num =>
       if (num == 10) throw DummyException("dummy exception")
       else BIO.fromEither(num.asRight[String])
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Failure(DummyException("dummy exception"))))
@@ -217,10 +217,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
 
   test("BIO.parTraverseN should be cancelable") { implicit s =>
     val numbers = List(2, 5, 10, 20, 40)
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       BIO.fromEither((num * num).asRight[String]).delayExecution(num.seconds)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, None)
@@ -235,10 +235,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
   test("BIO.parTraverseN should be stack safe for synchronous tasks with low parallelism") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 10000
     val numbers = 1.to(count).toList
-    val wander = BIO
+    val traverse = BIO
       .parTraverseN(parallelism = 10)(numbers)(num => BIO.fromEither(num.asRight[String]))
       .map(_.sum)
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Right(numbers.sum))))
@@ -247,10 +247,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
   test("BIO.parTraverseN should be stack safe for asynchronous tasks with low parallelism") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 10000
     val numbers = 1.to(count).toList
-    val wander = BIO
+    val traverse = BIO
       .parTraverseN(parallelism = 10)(numbers)(num => BIO.fromEither(num.asRight[String]).executeAsync)
       .map(_.sum)
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Right(numbers.sum))))
@@ -259,10 +259,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
   test("BIO.parTraverseN should be stack safe for synchronous tasks with high parallelism") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 10000
     val numbers = 1.to(count).toList
-    val wander = BIO
+    val traverse = BIO
       .parTraverseN(parallelism = count)(numbers)(num => BIO.fromEither(num.asRight[String]))
       .map(_.sum)
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Right(numbers.sum))))
@@ -271,10 +271,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
   test("BIO.parTraverseN should be stack safe for asynchronous tasks with high parallelism") { implicit s =>
     val count = if (Platform.isJVM) 100000 else 10000
     val numbers = 1.to(count).toList
-    val wander = BIO
+    val traverse = BIO
       .parTraverseN(parallelism = count)(numbers)(num => BIO.fromEither(num.asRight[String]).executeAsync)
       .map(_.sum)
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(f.value, Some(Success(Right(numbers.sum))))
@@ -284,10 +284,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
     val counter = AtomicInt(0)
     val numbers = List(2, 5, 10, 20, 40)
     val effect = BIO.evalAsync(counter.increment())
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       effect.map(_ => num * num)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(counter.get, 5)
@@ -298,10 +298,10 @@ object TaskParTraverseNSuite extends BaseTestSuite {
     val counter = AtomicInt(0)
     val numbers = List(2, 5, 10, 20, 40)
     val effect = BIO.evalAsync(counter.increment()).memoize
-    val wander = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
+    val traverse = BIO.parTraverseN(parallelism = 2)(numbers) { num =>
       effect.map(_ => num * num)
     }
-    val f = wander.attempt.runToFuture
+    val f = traverse.attempt.runToFuture
 
     s.tick()
     assertEquals(counter.get, 1)

--- a/core/shared/src/test/scala/monix/bio/TaskParTraverseSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskParTraverseSuite.scala
@@ -23,11 +23,11 @@ import monix.execution.internal.Platform
 import concurrent.duration._
 import scala.util.{Failure, Success}
 
-object TaskWanderSuite extends BaseTestSuite {
-  test("BIO.wander should execute in parallel for async tasks") { implicit s =>
+object TaskParTraverseSuite extends BaseTestSuite {
+  test("BIO.parTraverse should execute in parallel for async tasks") { implicit s =>
     val seq = Seq((1, 2), (2, 1), (3, 3))
     val f = BIO
-      .wander(seq) {
+      .parTraverse(seq) {
         case (i, d) =>
           BIO.evalAsync(i + 1).delayExecution(d.seconds)
       }
@@ -41,11 +41,11 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Seq(2, 3, 4))))
   }
 
-  test("BIO.wander should onError if one of the tasks terminates in error") { implicit s =>
+  test("BIO.parTraverse should onError if one of the tasks terminates in error") { implicit s =>
     val ex = 1000L
     val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
     val f = BIO
-      .wander(seq) {
+      .parTraverse(seq) {
         case (i, d) =>
           BIO
             .suspendTotal(if (i < 0) BIO.raiseError(ex) else BIO.now(i + 1))
@@ -60,11 +60,11 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Left(ex))))
   }
 
-  test("BIO.wander should onTerminate if one of the tasks terminates in unexpected error") { implicit s =>
+  test("BIO.parTraverse should onTerminate if one of the tasks terminates in unexpected error") { implicit s =>
     val ex = DummyException("dummy")
     val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
     val f = BIO
-      .wander(seq) {
+      .parTraverse(seq) {
         case (i, d) =>
           UIO
             .evalAsync(if (i < 0) throw ex else i + 1)
@@ -78,10 +78,10 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("BIO.wander should be canceled") { implicit s =>
+  test("BIO.parTraverse should be canceled") { implicit s =>
     val seq = Seq((1, 2), (2, 1), (3, 3))
     val f = BIO
-      .wander(seq) {
+      .parTraverse(seq) {
         case (i, d) => BIO.evalAsync(i + 1).delayExecution(d.seconds)
       }
       .runToFuture
@@ -96,21 +96,21 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("BIO.wander should be stack safe for synchronous tasks") { implicit s =>
+  test("BIO.parTraverse should be stack safe for synchronous tasks") { implicit s =>
     val count = if (Platform.isJVM) 200000 else 5000
     val seq = for (i <- 0 until count) yield 1
-    val composite = BIO.wander(seq)(BIO.now).map(_.sum)
+    val composite = BIO.parTraverse(seq)(BIO.now).map(_.sum)
     val result = composite.runToFuture
     s.tick()
     assertEquals(result.value, Some(Success(count)))
   }
 
-  test("BIO.wander runAsync multiple times") { implicit s =>
+  test("BIO.parTraverse runAsync multiple times") { implicit s =>
     var effect = 0
 
     val task1 = UIO.evalAsync { effect += 1; 3 }.memoize
 
-    val task2 = BIO.wander(Seq(0, 0, 0)) { _ =>
+    val task2 = BIO.parTraverse(Seq(0, 0, 0)) { _ =>
       task1 map { x =>
         effect += 1; x + 1
       }
@@ -125,9 +125,9 @@ object TaskWanderSuite extends BaseTestSuite {
     assertEquals(effect, 1 + 3 + 3)
   }
 
-  test("BIO.wander should wrap exceptions in the function") { implicit s =>
+  test("BIO.parTraverse should wrap exceptions in the function") { implicit s =>
     val ex = DummyException("dummy")
-    val task1 = BIO.wander(Seq(0)) { i =>
+    val task1 = BIO.parTraverse(Seq(0)) { i =>
       throw ex
       BIO.now(i)
     }

--- a/core/shared/src/test/scala/monix/bio/TaskParTraverseUnorderedSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskParTraverseUnorderedSuite.scala
@@ -24,11 +24,11 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-object TaskWanderUnorderedSuite extends BaseTestSuite {
-  test("BIO.wanderUnordered should execute in parallel") { implicit s =>
+object TaskParTraverseUnorderedSuite extends BaseTestSuite {
+  test("BIO.parTraverseUnordered should execute in parallel") { implicit s =>
     val seq = Seq((1, 2), (2, 1), (3, 3))
     val f = Task
-      .wanderUnordered(seq) {
+      .parTraverseUnordered(seq) {
         case (i, d) =>
           Task.evalAsync(i + 1).delayExecution(d.seconds)
       }
@@ -42,11 +42,11 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Seq(4, 2, 3))))
   }
 
-  test("Task.wanderUnordered should onError if one of the tasks terminates in error") { implicit s =>
+  test("Task.parTraverseUnordered should onError if one of the tasks terminates in error") { implicit s =>
     val ex = DummyException("dummy")
     val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
     val f = Task
-      .wanderUnordered(seq) {
+      .parTraverseUnordered(seq) {
         case (i, d) =>
           Task
             .evalAsync(if (i < 0) throw ex else i + 1)
@@ -60,10 +60,10 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("Task.wanderUnordered should be canceled") { implicit s =>
+  test("Task.parTraverseUnordered should be canceled") { implicit s =>
     val seq = Seq((1, 2), (2, 1), (3, 3))
     val f = Task
-      .wanderUnordered(seq) {
+      .parTraverseUnordered(seq) {
         case (i, d) => Task.evalAsync(i + 1).delayExecution(d.seconds)
       }
       .runToFuture
@@ -78,28 +78,28 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.wanderUnordered should run over an iterable") { implicit s =>
+  test("Task.parTraverseUnordered should run over an iterable") { implicit s =>
     val count = 10
     val seq = 0 until count
-    val sum = Task.wanderUnordered(seq)(x => Task.eval(x + 1)).map(_.sum)
+    val sum = Task.parTraverseUnordered(seq)(x => Task.eval(x + 1)).map(_.sum)
 
     val result = sum.runToFuture; s.tick()
     assertEquals(result.value.get, Success((count + 1) * count / 2))
   }
 
-  test("Task.wanderUnordered should be stack-safe on handling many tasks") { implicit s =>
+  test("Task.parTraverseUnordered should be stack-safe on handling many tasks") { implicit s =>
     val count = 10000
     val seq = for (i <- 0 until count) yield i
-    val sum = Task.wanderUnordered(seq)(x => Task.eval(x)).map(_.sum)
+    val sum = Task.parTraverseUnordered(seq)(x => Task.eval(x)).map(_.sum)
 
     val result = sum.runToFuture; s.tick()
     assertEquals(result.value.get, Success(count * (count - 1) / 2))
   }
 
-  test("Task.wanderUnordered should be stack safe on success") { implicit s =>
+  test("Task.parTraverseUnordered should be stack safe on success") { implicit s =>
     def fold[A](ta: Task[ListBuffer[A]], next: A): Task[ListBuffer[A]] =
       ta flatMap { acc =>
-        Task.wanderUnordered(Seq(acc, next)) { v =>
+        Task.parTraverseUnordered(Seq(acc, next)) { v =>
           Task.eval(v)
         }
       } map {
@@ -139,12 +139,12 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(result, Some(Success(count * (count - 1) / 2)))
   }
 
-  test("Task.wanderUnordered should log errors if multiple errors happen") { implicit s =>
+  test("Task.parTraverseUnordered should log errors if multiple errors happen") { implicit s =>
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
 
     val ex = DummyException("dummy1")
     var errorsThrow = 0
-    val gather = Task.wanderUnordered(Seq(0, 0)) { _ =>
+    val sequence = Task.parTraverseUnordered(Seq(0, 0)) { _ =>
       Task
         .raiseError[Int](ex)
         .executeAsync
@@ -155,7 +155,7 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
         .uncancelable
     }
 
-    val result = gather.runToFutureOpt
+    val result = sequence.runToFutureOpt
     s.tick()
 
     assertEquals(result.value, Some(Failure(ex)))
@@ -163,7 +163,7 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(errorsThrow, 2)
   }
 
-  test("Task.wanderUnordered runAsync multiple times") { implicit s =>
+  test("Task.parTraverseUnordered runAsync multiple times") { implicit s =>
     var effect = 0
     val task1 = Task.evalAsync {
       effect += 1; 3
@@ -173,7 +173,7 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
       effect += 1; x + 1
     }
 
-    val task3 = Task.wanderUnordered(List(0, 0, 0)) { _ =>
+    val task3 = Task.parTraverseUnordered(List(0, 0, 0)) { _ =>
       task2
     }
 
@@ -186,9 +186,9 @@ object TaskWanderUnorderedSuite extends BaseTestSuite {
     assertEquals(effect, 1 + 3 + 3)
   }
 
-  test("Task.wanderUnordered should wrap exceptions in the function") { implicit s =>
+  test("Task.parTraverseUnordered should wrap exceptions in the function") { implicit s =>
     val ex = DummyException("dummy")
-    val task1 = Task.wanderUnordered(Seq(0)) { _ =>
+    val task1 = Task.parTraverseUnordered(Seq(0)) { _ =>
       throw ex
     }
 

--- a/core/shared/src/test/scala/monix/bio/TaskParTraverseUnorderedSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskParTraverseUnorderedSuite.scala
@@ -42,7 +42,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Success(Seq(4, 2, 3))))
   }
 
-  test("Task.parTraverseUnordered should onError if one of the tasks terminates in error") { implicit s =>
+  test("BIO.parTraverseUnordered should onError if one of the tasks terminates in error") { implicit s =>
     val ex = DummyException("dummy")
     val seq = Seq((1, 3), (-1, 1), (3, 2), (3, 1))
     val f = Task
@@ -60,7 +60,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, Some(Failure(ex)))
   }
 
-  test("Task.parTraverseUnordered should be canceled") { implicit s =>
+  test("BIO.parTraverseUnordered should be canceled") { implicit s =>
     val seq = Seq((1, 2), (2, 1), (3, 3))
     val f = Task
       .parTraverseUnordered(seq) {
@@ -78,7 +78,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.parTraverseUnordered should run over an iterable") { implicit s =>
+  test("BIO.parTraverseUnordered should run over an iterable") { implicit s =>
     val count = 10
     val seq = 0 until count
     val sum = Task.parTraverseUnordered(seq)(x => Task.eval(x + 1)).map(_.sum)
@@ -87,7 +87,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(result.value.get, Success((count + 1) * count / 2))
   }
 
-  test("Task.parTraverseUnordered should be stack-safe on handling many tasks") { implicit s =>
+  test("BIO.parTraverseUnordered should be stack-safe on handling many tasks") { implicit s =>
     val count = 10000
     val seq = for (i <- 0 until count) yield i
     val sum = Task.parTraverseUnordered(seq)(x => Task.eval(x)).map(_.sum)
@@ -96,7 +96,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(result.value.get, Success(count * (count - 1) / 2))
   }
 
-  test("Task.parTraverseUnordered should be stack safe on success") { implicit s =>
+  test("BIO.parTraverseUnordered should be stack safe on success") { implicit s =>
     def fold[A](ta: Task[ListBuffer[A]], next: A): Task[ListBuffer[A]] =
       ta flatMap { acc =>
         Task.parTraverseUnordered(Seq(acc, next)) { v =>
@@ -139,7 +139,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(result, Some(Success(count * (count - 1) / 2)))
   }
 
-  test("Task.parTraverseUnordered should log errors if multiple errors happen") { implicit s =>
+  test("BIO.parTraverseUnordered should log errors if multiple errors happen") { implicit s =>
     implicit val opts = BIO.defaultOptions.disableAutoCancelableRunLoops
 
     val ex = DummyException("dummy1")
@@ -163,7 +163,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(errorsThrow, 2)
   }
 
-  test("Task.parTraverseUnordered runAsync multiple times") { implicit s =>
+  test("BIO.parTraverseUnordered runAsync multiple times") { implicit s =>
     var effect = 0
     val task1 = Task.evalAsync {
       effect += 1; 3
@@ -186,7 +186,7 @@ object TaskParTraverseUnorderedSuite extends BaseTestSuite {
     assertEquals(effect, 1 + 3 + 3)
   }
 
-  test("Task.parTraverseUnordered should wrap exceptions in the function") { implicit s =>
+  test("BIO.parTraverseUnordered should wrap exceptions in the function") { implicit s =>
     val ex = DummyException("dummy")
     val task1 = Task.parTraverseUnordered(Seq(0)) { _ =>
       throw ex


### PR DESCRIPTION
#75 

@Avasil I see we don't have a `TaskDeprecated` object like `monix.eval`. I hope what I have done is correct.

I can add and implement the same Deprecation Strategy if you would like?

Please let me know if I should fix it :-)