### PR TITLE
Add method to lift recoverable exceptions to ADT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ project/plugins/project/
 /website/static/api/
 /website/variables.js
 /website/yarn.lock
+
+.bloop
+.metals
+.vscode
+.bsp
+metals.sbt

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2059,12 +2059,8 @@ sealed abstract class IO[+E, +A] extends Serializable {
   final def onErrorRecoverWith[E1 >: E, B >: A](pf: PartialFunction[E, IO[E1, B]]): IO[E1, B] =
     onErrorHandleWith(ex => pf.applyOrElse(ex, raiseConstructor[E]))
 
-  /** Creates a new task that will will transform recoverable errors
-    * using supplied partial function `pf`.
-    *
-    * Use this method to lift recoverable errors into domain specific error ADT
-    *
-    * Exceptions matched by pf are raised in the typed error channel. All other exceptions are raised in the internal error channel.
+  /** Use this method to lift a subset of errors into domain-specific errors.
+    * Unmatched errors will be considered non-recoverable and will terminate IO.
     *
     * Example:
     * {{{
@@ -2075,7 +2071,6 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *     case ex: NumberFormatException => ErrorA(s"Invalid input: \\${ex.getMessage}")
     *   }
     * }}}
-    * See [[mapErrorPartial]] for the version that takes a pure partial function
     */
   final def mapErrorPartialWith[E1, B >: A](pf: PartialFunction[E, IO[E1, B]])(implicit E: E <:< Throwable): IO[E1, B] =
     onErrorHandleWith(ex => pf.applyOrElse(ex, (ex: E) => IO.terminate(E(ex))))
@@ -2263,12 +2258,8 @@ sealed abstract class IO[+E, +A] extends Serializable {
     IO.FlatMap(this, IO.MapError[E, E1, A](f), trace)
   }
 
-  /** Creates a new task that will will transform recoverable errors
-    * using supplied partial function `pf`.
-    *
-    * Use this method to lift recoverable errors into domain specific error ADT
-    *
-    * Exceptions matched by pf are raised in the typed error channel. All other exceptions are raised in the internal error channel.
+  /** Use this method to lift a subset of errors into domain-specific errors.
+    * Unmatched errors will be considered non-recoverable and will terminate IO.
     *
     * Example:
     * {{{
@@ -2279,7 +2270,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *     case ex: NumberFormatException => ErrorA(s"Invalid input: \\${ex.getMessage}")
     *   }
     * }}}
-    * See [[mapErrorPartialWith]] for the version that takes an [[IO]] in it's partial function
+    * See [[mapError]] for the version that takes a total function.
     */
   final def mapErrorPartial[E1](pf: PartialFunction[E, E1])(implicit E: E <:< Throwable): IO[E1, A] = {
     val trace = IOTracing.getTrace(pf.getClass)

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2060,7 +2060,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     onErrorHandleWith(ex => pf.applyOrElse(ex, raiseConstructor[E]))
 
   /** Use this method to lift a subset of errors into domain-specific errors.
-    * Unmatched errors will be considered non-recoverable and will terminate IO.
+    * Not matched errors will be considered non-recoverable and will terminate IO.
     *
     * Example:
     * {{{
@@ -2259,7 +2259,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
   }
 
   /** Use this method to lift a subset of errors into domain-specific errors.
-    * Unmatched errors will be considered non-recoverable and will terminate IO.
+    * Not matched errors will be considered non-recoverable and will terminate IO.
     *
     * Example:
     * {{{

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2072,7 +2072,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *   case class ErrorA(message: String) extends DomainError
     *
     *   val io: IO[DomainError, String] = IO("1").mapErrorPartial {
-    *     case ex: NumberFormatException => IO.raiseError(ErrorA(s"Invalid input: \\${ex.getMessage}"))
+    *     case ex: NumberFormatException => ErrorA(s"Invalid input: \\${ex.getMessage}")
     *   }
     * }}}
     * See [[mapErrorPartial]] for the version that takes a pure partial function

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2071,7 +2071,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *   sealed trait DomainError
     *   case class ErrorA(message: String) extends DomainError
     *
-    *   val io: IO[DomainError, String] = IO("1").mapErrorPartial {
+    *   val io: IO[DomainError, Int] = IO("1".toInt).mapErrorPartial {
     *     case ex: NumberFormatException => ErrorA(s"Invalid input: \\${ex.getMessage}")
     *   }
     * }}}
@@ -2275,7 +2275,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *   sealed trait DomainError
     *   case class ErrorA(message: String) extends DomainError
     *
-    *   val io: IO[DomainError, String] = IO("1").mapErrorPartial {
+    *   val io: IO[DomainError, Int] = IO("1".toInt).mapErrorPartial {
     *     case ex: NumberFormatException => ErrorA(s"Invalid input: \\${ex.getMessage}")
     *   }
     * }}}

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2059,6 +2059,9 @@ sealed abstract class IO[+E, +A] extends Serializable {
   final def onErrorRecoverWith[E1 >: E, B >: A](pf: PartialFunction[E, IO[E1, B]]): IO[E1, B] =
     onErrorHandleWith(ex => pf.applyOrElse(ex, raiseConstructor[E]))
 
+  final def mapErrorPartial[E1, B >: A](pf: PartialFunction[E, IO[E1, B]])(implicit E: E <:< Throwable): IO[E1, B] =
+    onErrorHandleWith(ex => pf.applyOrElse(ex, (ex: E) => IO.terminate(E(ex))))
+
   /** Creates a new task that will handle any matching throwable that
     * this task might emit by executing another task.
     *

--- a/core/shared/src/main/scala/monix/bio/IO.scala
+++ b/core/shared/src/main/scala/monix/bio/IO.scala
@@ -2071,7 +2071,7 @@ sealed abstract class IO[+E, +A] extends Serializable {
     *   sealed trait DomainError
     *   case class ErrorA(message: String) extends DomainError
     *
-    *   val io: IO[DomainError, String] = IO("1".).mapErrorPartial {
+    *   val io: IO[DomainError, String] = IO("1").mapErrorPartial {
     *     case ex: NumberFormatException => IO.raiseError(ErrorA(s"Invalid input: \\${ex.getMessage}"))
     *   }
     * }}}

--- a/core/shared/src/test/scala/monix/bio/TaskErrorSuite.scala
+++ b/core/shared/src/test/scala/monix/bio/TaskErrorSuite.scala
@@ -23,7 +23,6 @@ import monix.execution.internal.Platform
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import java.nio.file.NoSuchFileException
 
 object TaskErrorSuite extends BaseTestSuite {
   test("IO.attempt should expose typed error") { implicit s =>
@@ -339,7 +338,7 @@ object TaskErrorSuite extends BaseTestSuite {
   test("IO#mapErrorPartial should handle recoverable exceptions") { implicit s =>
     val ex = DummyException("dummy")
     val io: IO[String, Int] = IO(throw ex).mapErrorPartial { case e: DummyException =>
-      IO.raiseError(e.message)
+      e.message
     }
 
     val f = io.attempt.runToFuture
@@ -349,7 +348,29 @@ object TaskErrorSuite extends BaseTestSuite {
 
   test("IO#mapErrorPartial should terminate on non-recoverable exceptions") { implicit s =>
     val ex = DummyException("dummy")
-    val io: IO[String, Int] = IO(throw ex).mapErrorPartial { case e: NoSuchFileException =>
+    val io: IO[String, Int] = IO(throw ex).mapErrorPartial { case e: IllegalArgumentException =>
+      "not found"
+    }
+
+    val f = io.attempt.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Failure(ex)))
+  }
+
+  test("IO#mapErrorPartialWith should handle recoverable exceptions") { implicit s =>
+    val ex = DummyException("dummy")
+    val io: IO[String, Int] = IO(throw ex).mapErrorPartialWith { case e: DummyException =>
+      IO.raiseError(e.message)
+    }
+
+    val f = io.attempt.runToFuture
+    s.tick()
+    assertEquals(f.value, Some(Success(Left("dummy"))))
+  }
+
+  test("IO#mapErrorPartialWith should terminate on non-recoverable exceptions") { implicit s =>
+    val ex = DummyException("dummy")
+    val io: IO[String, Int] = IO(throw ex).mapErrorPartialWith { case e: IllegalArgumentException =>
       IO.raiseError("not found")
     }
 


### PR DESCRIPTION
This PR adds methods to lift recoverable exceptions to domain-specific ADT as typed errors. Unhandled exceptions (i.e non-recoverable exceptions) terminate the task.

The methods convert `IO[Throwable, A] =>  IO[DomainError, A]` using either 
1.  partial function `Throwable => DomainError`
2.  partial function `Throwable => IO[DomainError,A]`

Examples - 
1. Recoverable exceptions - 
``` scala
case class DomainError(message: String)
val io: IO[DomainError, Unit] = IO(throw new DomainException).mapErrorPartialWith {
  case _ : DomainException => IO.raiseError(DomainError("dummy"))
  }
```
2. Non-recoverable exceptions - 
``` scala
case class DomainError(message: String)
val io: IO[DomainError, Unit] = IO(throw new NonRecoverableException).mapErrorPartialWith {
  case _ : DomainException => IO.raiseError(DomainError("dummy"))
  } // gives an IO that terminates with NonRecoverableException
```

TODO -
1. ~Name of the method needs to be finalized, currently it is `mapErrorPartial`~
2. Add scaladoc for methods
3. Add more test cases